### PR TITLE
Canvas draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@ CHANGELOG
 
 ## main
 
+The following are differences from Ratatui:
+
 - Added `Grid` widget (allows "layouts" as widgets) #18
-- Blocks have a widget instead of widgets having blocks #22
+- `Block` has a widget instead of widgets having blocks #22
 - Introduced `Sprite` shape
 - Added `TextShape` shape which renders fonts.
 - Added `ImageShape` widget to render images on the canvas #36.
+- Added `Canvas#draw(Widget)` to avoid using the closure for most cases. #51
 

--- a/example/demo/src/App.php
+++ b/example/demo/src/App.php
@@ -2,7 +2,6 @@
 
 namespace PhpTui\Tui\Example\Demo;
 
-use Error;
 use PhpTui\Term\Actions;
 use PhpTui\Term\Event\CharKeyEvent;
 use PhpTui\Term\Terminal;
@@ -17,7 +16,6 @@ use PhpTui\Tui\Example\Demo\Page\ItemListPage;
 use PhpTui\Tui\Example\Demo\Page\SpritePage;
 use PhpTui\Tui\Example\Demo\Page\TablePage;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Display;

--- a/example/docs/shape/circle.php
+++ b/example/docs/shape/circle.php
@@ -6,7 +6,6 @@ use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 use PhpTui\Tui\Widget\Canvas\Shape\Circle;
 
 require 'vendor/autoload.php';
@@ -15,9 +14,7 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(-1, 21, -1, 21)
         ->marker(Marker::Dot)
-        ->paint(function (CanvasContext $context): void {
-            $context->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green));
-        })
+        ->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green))
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/circle.php
+++ b/example/docs/shape/circle.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -11,10 +10,8 @@ use PhpTui\Tui\Widget\Canvas\Shape\Circle;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(-1, 21, -1, 21)
         ->marker(Marker::Dot)
         ->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green))
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/imageShape.php
+++ b/example/docs/shape/imageShape.php
@@ -6,7 +6,6 @@ use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 
 require 'vendor/autoload.php';
 
@@ -14,15 +13,11 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(0, 320, 0, 240)
         ->marker(Marker::HalfBlock)
-        ->paint(function (CanvasContext $context): void {
-
-            $context->draw(
-                // this is expensive, don't do this on each frame if you are
-                // animating!
-                ImageShape::fromFilename(__DIR__ . '/example.jpg')
-            );
-
-        })
+        ->draw(
+            // this is expensive, don't do this on each frame if you are
+            // animating!
+            ImageShape::fromFilename(__DIR__ . '/example.jpg')
+        )
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/imageShape.php
+++ b/example/docs/shape/imageShape.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\ImageMagick\Shape\ImageShape;
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -10,7 +9,7 @@ use PhpTui\Tui\Widget\Canvas;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 320, 0, 240)
         ->marker(Marker::HalfBlock)
         ->draw(
@@ -18,6 +17,4 @@ $display->draw(function (Buffer $buffer): void {
             // animating!
             ImageShape::fromFilename(__DIR__ . '/example.jpg')
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/line.php
+++ b/example/docs/shape/line.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -11,7 +10,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Line;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 20, 0, 20)
         ->marker(Marker::Dot)
         ->draw(Line::fromPrimitives(
@@ -21,6 +20,4 @@ $display->draw(function (Buffer $buffer): void {
             20, // y2
             AnsiColor::Green
         ))
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/line.php
+++ b/example/docs/shape/line.php
@@ -6,7 +6,6 @@ use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 use PhpTui\Tui\Widget\Canvas\Shape\Line;
 
 require 'vendor/autoload.php';
@@ -15,16 +14,13 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(0, 20, 0, 20)
         ->marker(Marker::Dot)
-        ->paint(function (CanvasContext $context): void {
-
-            $context->draw(Line::fromPrimitives(
-                0,  // x1
-                0,  // y1
-                20, // x2
-                20, // y2
-                AnsiColor::Green
-            ));
-        })
+        ->draw(Line::fromPrimitives(
+            0,  // x1
+            0,  // y1
+            20, // x2
+            20, // y2
+            AnsiColor::Green
+        ))
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/map.php
+++ b/example/docs/shape/map.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -12,7 +11,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\MapResolution;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(-180, 180, -90, 90)
         ->marker(Marker::Braille)
         ->draw(
@@ -20,6 +19,4 @@ $display->draw(function (Buffer $buffer): void {
                 ->resolution(MapResolution::High)
                 ->color(AnsiColor::Green)
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/map.php
+++ b/example/docs/shape/map.php
@@ -6,7 +6,6 @@ use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 use PhpTui\Tui\Widget\Canvas\Shape\Map;
 use PhpTui\Tui\Widget\Canvas\Shape\MapResolution;
 
@@ -16,12 +15,11 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(-180, 180, -90, 90)
         ->marker(Marker::Braille)
-        ->paint(function (CanvasContext $context): void {
-
-            $context->draw(
-                Map::default()->resolution(MapResolution::High)->color(AnsiColor::Green)
-            );
-        })
+        ->draw(
+            Map::default()
+                ->resolution(MapResolution::High)
+                ->color(AnsiColor::Green)
+        )
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/points.php
+++ b/example/docs/shape/points.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;

--- a/example/docs/shape/points.php
+++ b/example/docs/shape/points.php
@@ -11,7 +11,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Points;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 10, 0, 10)
         ->marker(Marker::Dot)
         ->draw(
@@ -23,6 +23,4 @@ $display->draw(function (Buffer $buffer): void {
                 [8, 8],
             ], AnsiColor::Black)
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/points.php
+++ b/example/docs/shape/points.php
@@ -6,7 +6,6 @@ use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 use PhpTui\Tui\Widget\Canvas\Shape\Points;
 
 require 'vendor/autoload.php';
@@ -15,18 +14,15 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(0, 10, 0, 10)
         ->marker(Marker::Dot)
-        ->paint(function (CanvasContext $context): void {
-
-            $context->draw(
-                Points::new([
-                    [0, 0],
-                    [2, 2],
-                    [4, 4],
-                    [6, 6],
-                    [8, 8],
-                ], AnsiColor::Black)
-            );
-        })
+        ->draw(
+            Points::new([
+                [0, 0],
+                [2, 2],
+                [4, 4],
+                [6, 6],
+                [8, 8],
+            ], AnsiColor::Black)
+        )
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/rectangle.php
+++ b/example/docs/shape/rectangle.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -11,7 +10,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Rectangle;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 10, 0, 10)
         ->marker(Marker::Dot)
         ->draw(
@@ -23,6 +22,4 @@ $display->draw(function (Buffer $buffer): void {
                 AnsiColor::Green
             )
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/rectangle.php
+++ b/example/docs/shape/rectangle.php
@@ -6,7 +6,6 @@ use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 use PhpTui\Tui\Widget\Canvas\Shape\Rectangle;
 
 require 'vendor/autoload.php';
@@ -15,19 +14,15 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(0, 10, 0, 10)
         ->marker(Marker::Dot)
-        ->paint(function (CanvasContext $context): void {
-
-            $context->draw(
-                Rectangle::fromPrimitives(
-                    0,
-                    0,
-                    10,
-                    10,
-                    AnsiColor::Green
-                )
-            );
-
-        })
+        ->draw(
+            Rectangle::fromPrimitives(
+                0,
+                0,
+                10,
+                10,
+                AnsiColor::Green
+            )
+        )
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/sprite.php
+++ b/example/docs/shape/sprite.php
@@ -7,7 +7,6 @@ use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 use PhpTui\Tui\Widget\Canvas\Shape\Sprite;
 
 require 'vendor/autoload.php';
@@ -16,29 +15,25 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(0, 20, 0, 10)
         ->marker(Marker::Braille)
-        ->paint(function (CanvasContext $context): void {
-
-            $context->draw(
-                new Sprite(
-                    rows: [
-                        ' XXX ',
-                        'X   X ',
-                        'X   X ',
-                        ' XXX ',
-                        '  X',
-                        'XXXXX',
-                        '  X       ', // rows do not need
-                        '  X       ', // equals numbers of chars
-                        ' X X     ',
-                        'X   X    ',
-                    ],
-                    color: AnsiColor::Blue,
-                    density: 4,
-                    position: FloatPosition::at(0, 0),
-                )
-            );
-
-        })
+        ->draw(
+            new Sprite(
+                rows: [
+                    ' XXX ',
+                    'X   X ',
+                    'X   X ',
+                    ' XXX ',
+                    '  X',
+                    'XXXXX',
+                    '  X       ', // rows do not need
+                    '  X       ', // equals numbers of chars
+                    ' X X     ',
+                    'X   X    ',
+                ],
+                color: AnsiColor::Blue,
+                density: 4,
+                position: FloatPosition::at(0, 0),
+            )
+        )
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/sprite.php
+++ b/example/docs/shape/sprite.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;
@@ -12,7 +11,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Sprite;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 20, 0, 10)
         ->marker(Marker::Braille)
         ->draw(
@@ -34,6 +33,4 @@ $display->draw(function (Buffer $buffer): void {
                 position: FloatPosition::at(0, 0),
             )
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/textShape.php
+++ b/example/docs/shape/textShape.php
@@ -9,7 +9,6 @@ use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Widget\Canvas;
-use PhpTui\Tui\Widget\Canvas\CanvasContext;
 
 require 'vendor/autoload.php';
 
@@ -21,18 +20,14 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer) use ($registry): void {
     Canvas::fromIntBounds(0, 50, 0, 20)
         ->marker(Marker::Block)
-        ->paint(function (CanvasContext $context) use ($registry) : void {
-
-            $context->draw(
-                new TextShape(
-                    font: $registry->get('default'),
-                    text: 'Hello!',
-                    color: AnsiColor::Green,
-                    position: FloatPosition::at(10, 7),
-                ),
-            );
-
-        })
+        ->draw(
+            new TextShape(
+                font: $registry->get('default'),
+                text: 'Hello!',
+                color: AnsiColor::Green,
+                position: FloatPosition::at(10, 7),
+            ),
+        )
         ->render($buffer->area(), $buffer);
 });
 $display->flush();

--- a/example/docs/shape/textShape.php
+++ b/example/docs/shape/textShape.php
@@ -17,7 +17,7 @@ require 'vendor/autoload.php';
 $registry = FontRegistry::default();
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer) use ($registry): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 50, 0, 20)
         ->marker(Marker::Block)
         ->draw(
@@ -28,6 +28,4 @@ $display->draw(function (Buffer $buffer) use ($registry): void {
                 position: FloatPosition::at(10, 7),
             ),
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/textShape.php
+++ b/example/docs/shape/textShape.php
@@ -4,7 +4,6 @@ use PhpTui\Tui\Adapter\Bdf\FontRegistry;
 use PhpTui\Tui\Adapter\Bdf\Shape\TextShape;
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;

--- a/example/docs/widget/block.php
+++ b/example/docs/widget/block.php
@@ -21,4 +21,3 @@ $display->draw(function (Buffer $buffer): void {
         ->widget(Paragraph::new(Text::raw('This is a block example')))
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/canvas.php
+++ b/example/docs/widget/canvas.php
@@ -14,8 +14,14 @@ require 'vendor/autoload.php';
 $display = Display::fullscreen(PhpTermBackend::new());
 $display->draw(function (Buffer $buffer): void {
     Canvas::fromIntBounds(-1, 21, -1, 21)
+        // the marker determines both the effective resolution of
+        // the canvas and the "mark" that is made
         ->marker(Marker::Dot)
+
+        // note can use `$canvas->draw($shape)` without the closure for most
+        // cases
         ->paint(function (CanvasContext $context): void {
+
             $context->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green));
         })
         ->render($buffer->area(), $buffer);

--- a/example/docs/widget/canvas.php
+++ b/example/docs/widget/canvas.php
@@ -26,4 +26,3 @@ $display->draw(function (Buffer $buffer): void {
         })
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/canvas.php
+++ b/example/docs/widget/canvas.php
@@ -18,8 +18,8 @@ $display->draw(function (Buffer $buffer): void {
         // the canvas and the "mark" that is made
         ->marker(Marker::Dot)
 
-        // note can use `$canvas->draw($shape)` without the closure for most
-        // cases
+        // note can use `$canvas->draw($shape, ...)` without the closure for
+        // most cases
         ->paint(function (CanvasContext $context): void {
 
             $context->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green));

--- a/example/docs/widget/chart.php
+++ b/example/docs/widget/chart.php
@@ -48,4 +48,3 @@ $display->draw(function (Buffer $buffer): void {
         )
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/grid.php
+++ b/example/docs/widget/grid.php
@@ -35,4 +35,3 @@ $display->draw(function (Buffer $buffer): void {
         )
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/itemList.php
+++ b/example/docs/widget/itemList.php
@@ -23,4 +23,3 @@ $display->draw(function (Buffer $buffer): void {
         )
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/paragraph.php
+++ b/example/docs/widget/paragraph.php
@@ -20,4 +20,3 @@ $display->draw(function (Buffer $buffer): void {
         )
     )->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/table.php
+++ b/example/docs/widget/table.php
@@ -44,4 +44,3 @@ $display->draw(function (Buffer $buffer): void {
             ]),
         )->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/src/Model/Display.php
+++ b/src/Model/Display.php
@@ -5,6 +5,8 @@ namespace PhpTui\Tui\Model;
 use Closure;
 use PhpTui\Tui\Model\Viewport\Fullscreen;
 use PhpTui\Tui\Model\Viewport\Inline;
+use PhpTui\Tui\Widget\Canvas\Shape;
+use PhpTui\Tui\Widget\Canvas\Shape\Points;
 
 final class Display
 {
@@ -57,6 +59,9 @@ final class Display
     }
 
     /**
+     * Synchronizes terminal size, calls the rendering closure, flushes the current internal state
+     * and prepares for the next draw call.
+     *
      * @param Closure(Buffer): void $closure
      */
     public function draw(Closure $closure): void
@@ -67,6 +72,21 @@ final class Display
         $this->flush();
         $this->swapBuffers();
         $this->backend->flush();
+    }
+
+    /**
+     * Synchronizes terminal size, renders the given widget, flushes the current internal state
+     * and prepares for the next draw call.
+     *
+     * This is the same as Draw but instead of a closure you pass a single
+     * widget (usually a Grid widget).
+     */
+    public function render(Widget $widget): void
+    {
+        $buffer = $this->buffer();
+        $this->draw(function () use ($widget, $buffer) {
+            $widget->render($buffer->area(), $buffer);
+        });
     }
 
     private function autoresize(): void

--- a/src/Model/Display.php
+++ b/src/Model/Display.php
@@ -81,7 +81,7 @@ final class Display
      * This is the same as Draw but instead of a closure you pass a single
      * widget (usually a Grid widget).
      */
-    public function render(Widget $widget): void
+    public function drawWidget(Widget $widget): void
     {
         $buffer = $this->buffer();
         $this->draw(function () use ($widget, $buffer) {

--- a/src/Model/Display.php
+++ b/src/Model/Display.php
@@ -5,8 +5,6 @@ namespace PhpTui\Tui\Model;
 use Closure;
 use PhpTui\Tui\Model\Viewport\Fullscreen;
 use PhpTui\Tui\Model\Viewport\Inline;
-use PhpTui\Tui\Widget\Canvas\Shape;
-use PhpTui\Tui\Widget\Canvas\Shape\Points;
 
 final class Display
 {
@@ -84,7 +82,7 @@ final class Display
     public function drawWidget(Widget $widget): void
     {
         $buffer = $this->buffer();
-        $this->draw(function () use ($widget, $buffer) {
+        $this->draw(function () use ($widget, $buffer): void {
             $widget->render($buffer->area(), $buffer);
         });
     }

--- a/src/Widget/Canvas.php
+++ b/src/Widget/Canvas.php
@@ -179,7 +179,7 @@ final class Canvas implements Widget
      * If you need to do more complex things with the canvas use the painter
      * closure to operate directly on the CanvasContext.
      *
-     * You can call this method times
+     * You can call this method multiple times
      */
     public function draw(Shape ...$shapes): self
     {

--- a/src/Widget/Canvas.php
+++ b/src/Widget/Canvas.php
@@ -178,10 +178,14 @@ final class Canvas implements Widget
      *
      * If you need to do more complex things with the canvas use the painter
      * closure to operate directly on the CanvasContext.
+     *
+     * You can call this method times
      */
-    public function draw(Shape $shape): self
+    public function draw(Shape ...$shapes): self
     {
-        $this->shapes[] = $shape;
+        foreach ($shapes as $shape) {
+            $this->shapes[] = $shape;
+        }
         return $this;
     }
 }

--- a/src/Widget/Canvas.php
+++ b/src/Widget/Canvas.php
@@ -13,12 +13,18 @@ use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Widget\Canvas\CanvasContext;
+use PhpTui\Tui\Widget\Canvas\Shape;
 
 /**
  * The canvas widget provides a surface, of arbitrary scale, upon which shapes can be drawn.
  */
 final class Canvas implements Widget
 {
+    /**
+     * @var Shape[]
+     */
+    private array $shapes = [];
+
     private function __construct(
         /**
          * Bounds of the X Axis. Must be set if the canvas is to render.
@@ -58,9 +64,6 @@ final class Canvas implements Widget
     public function render(Area $area, Buffer $buffer): void
     {
         $painter = $this->painter;
-        if (null === $painter) {
-            return;
-        }
 
         $buffer->setStyle($area, Style::default()->bg($this->backgroundColor));
         $width = $area->width;
@@ -72,7 +75,23 @@ final class Canvas implements Widget
             $this->yBounds,
             $this->marker,
         );
-        $painter($context);
+
+        $saveLayer = false;
+        foreach ($this->shapes as $shape) {
+            $context->draw($shape);
+            $context->saveLayer();
+            $saveLayer = true;
+        }
+
+        if ($saveLayer) {
+            // if shapes were added then save the layer before
+            // calling the closure
+            $context->saveLayer();
+        }
+
+        if ($painter !== null) {
+            $painter($context);
+        }
         $context->finish();
 
         foreach ($context->layers as $layer) {
@@ -150,5 +169,19 @@ final class Canvas implements Widget
             backgroundColor: AnsiColor::Reset,
             marker: Marker::Braille,
         );
+    }
+
+    /**
+     * Shortcut for adding shapes to the canvas.
+     *
+     * Any shapes added here will be added in the first layer.
+     *
+     * If you need to do more complex things with the canvas use the painter
+     * closure to operate directly on the CanvasContext.
+     */
+    public function draw(Shape $shape): self
+    {
+        $this->shapes[] = $shape;
+        return $this;
     }
 }

--- a/tests/Model/DisplayTest.php
+++ b/tests/Model/DisplayTest.php
@@ -72,13 +72,12 @@ class DisplayTest extends TestCase
         ], AnsiColor::Green)));
 
         self::assertEquals(
-
             <<<'EOT'
-               •
-              • 
-             •  
-            •   
-            EOT,
+                   •
+                  • 
+                 •  
+                •   
+                EOT,
             $backend->flushed()
         );
     }

--- a/tests/Model/DisplayTest.php
+++ b/tests/Model/DisplayTest.php
@@ -67,7 +67,7 @@ class DisplayTest extends TestCase
     {
         $backend = DummyBackend::fromDimensions(4, 4);
         $terminal = Display::fullscreen($backend);
-        $terminal->render(Canvas::fromIntBounds(0, 3, 0, 3)->marker(Marker::Dot)->draw(Points::new([
+        $terminal->drawWidget(Canvas::fromIntBounds(0, 3, 0, 3)->marker(Marker::Dot)->draw(Points::new([
             [3, 3], [2, 2], [1, 1], [0, 0]
         ], AnsiColor::Green)));
 

--- a/tests/Model/DisplayTest.php
+++ b/tests/Model/DisplayTest.php
@@ -2,11 +2,15 @@
 
 namespace PhpTui\Tui\Tests\Model;
 
+use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Backend\DummyBackend;
 use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Display;
 use PHPUnit\Framework\TestCase;
+use PhpTui\Tui\Widget\Canvas;
+use PhpTui\Tui\Widget\Canvas\Shape\Points;
 
 class DisplayTest extends TestCase
 {
@@ -55,6 +59,26 @@ class DisplayTest extends TestCase
                   x 
                    x
                 EOT,
+            $backend->flushed()
+        );
+    }
+
+    public function testRender(): void
+    {
+        $backend = DummyBackend::fromDimensions(4, 4);
+        $terminal = Display::fullscreen($backend);
+        $terminal->render(Canvas::fromIntBounds(0, 3, 0, 3)->marker(Marker::Dot)->draw(Points::new([
+            [3, 3], [2, 2], [1, 1], [0, 0]
+        ], AnsiColor::Green)));
+
+        self::assertEquals(
+
+            <<<'EOT'
+               •
+              • 
+             •  
+            •   
+            EOT,
             $backend->flushed()
         );
     }

--- a/tests/Widget/CanvasTest.php
+++ b/tests/Widget/CanvasTest.php
@@ -11,6 +11,7 @@ use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\Line as DTLLine;
 use PhpTui\Tui\Widget\Canvas;
 use PhpTui\Tui\Widget\Canvas\CanvasContext;
+use PhpTui\Tui\Widget\Canvas\Shape\Circle;
 use PhpTui\Tui\Widget\Canvas\Shape\Line;
 use Generator;
 use PHPUnit\Framework\TestCase;
@@ -23,6 +24,34 @@ class CanvasTest extends TestCase
         self::assertEquals(AxisBounds::new(1, 320), $canvas->xBounds);
         self::assertEquals(AxisBounds::new(2, 240), $canvas->yBounds);
     }
+
+    public function testDraw(): void
+    {
+        $area = Area::fromDimensions(10, 10);
+        $buffer = Buffer::filled($area, Cell::fromChar('x'));
+
+        $canvas = Canvas::fromIntBounds(0, 10, 0, 10);
+        $canvas->draw(Circle::fromPrimitives(5, 5, 5, AnsiColor::Green));
+        $canvas->render($area, $buffer);
+        $expected = [
+            'x⢀⡴⠋⠉⠉⠳⣄xx',
+            '⢀⡞xxxxx⠘⣆x',
+            '⡼xxxxxxx⠸⡄',
+            '⡇xxxxxxxx⡇',
+            '⡇xxxxxxxx⣇',
+            '⡇xxxxxxxx⡇',
+            '⡇xxxxxxxx⡇',
+            '⢹⡀xxxxxx⣸⠁',
+            'x⢳⡀xxxx⣰⠃x',
+            'xx⠙⠦⢤⠤⠞⠁xx',
+        ];
+        self::assertEquals($expected, $buffer->toLines());
+
+        $buffer = Buffer::filled($area, Cell::fromChar('x'));
+        $canvas->render($area, $buffer);
+        self::assertEquals($expected, $buffer->toLines());
+    }
+
     /**
      * @dataProvider provideRenderMarker
      * @param string[] $expected

--- a/tests/Widget/CanvasTest.php
+++ b/tests/Widget/CanvasTest.php
@@ -52,6 +52,27 @@ class CanvasTest extends TestCase
         self::assertEquals($expected, $buffer->toLines());
     }
 
+    public function testDrawMultiple(): void
+    {
+        $area = Area::fromDimensions(5, 5);
+        $buffer = Buffer::filled($area, Cell::fromChar('x'));
+
+        $canvas = Canvas::fromIntBounds(0, 5, 0, 5);
+        $canvas->draw(
+            Circle::fromPrimitives(1, 1, 1, AnsiColor::Green),
+            Circle::fromPrimitives(4, 4, 1, AnsiColor::Green),
+        );
+        $canvas->render($area, $buffer);
+        $expected = [
+            'xx⢸⠉⣇',
+            'xx⠸⣄⡇',
+            '⣀⡀xxx',
+            '⡇⢹xxx',
+            '⢧⠼xxx',
+        ];
+        self::assertEquals($expected, $buffer->toLines());
+    }
+
     /**
      * @dataProvider provideRenderMarker
      * @param string[] $expected


### PR DESCRIPTION
Now that we have a `Grid` widget all of the existing functionality can be achieved by using `drawWidget(Widget)` and not `draw(Closure)`. I'm leaving the closure there for now (as with Ratatui) but could perhaps remove it in the future.