### PR TITLE
Display draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ CHANGELOG
 
 The following are differences from Ratatui:
 
+- Renamed `Terminal` to `Display` to avoid naming conflicts with PHP-Terms
+  `Terminal` (and it's also perhaps more accurate).
 - Added `Grid` widget (allows "layouts" as widgets) #18
 - `Block` has a widget instead of widgets having blocks #22
 - Introduced `Sprite` shape
 - Added `TextShape` shape which renders fonts.
 - Added `ImageShape` widget to render images on the canvas #36.
 - Added `Canvas#draw(Widget)` to avoid using the closure for most cases. #51
+- Added `Display#drawWidget(Widget)` to avoid using the closure for most cases. #55
 

--- a/example/demo/src/App.php
+++ b/example/demo/src/App.php
@@ -2,7 +2,6 @@
 
 namespace PhpTui\Tui\Example\Demo;
 
-use Error;
 use PhpTui\Term\Actions;
 use PhpTui\Term\Event\CharKeyEvent;
 use PhpTui\Term\Terminal;
@@ -17,7 +16,6 @@ use PhpTui\Tui\Example\Demo\Page\ItemListPage;
 use PhpTui\Tui\Example\Demo\Page\SpritePage;
 use PhpTui\Tui\Example\Demo\Page\TablePage;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Display;

--- a/example/docs/shape/circle.php
+++ b/example/docs/shape/circle.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -11,10 +10,8 @@ use PhpTui\Tui\Widget\Canvas\Shape\Circle;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(-1, 21, -1, 21)
         ->marker(Marker::Dot)
         ->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green))
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/imageShape.php
+++ b/example/docs/shape/imageShape.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\ImageMagick\Shape\ImageShape;
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -10,7 +9,7 @@ use PhpTui\Tui\Widget\Canvas;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 320, 0, 240)
         ->marker(Marker::HalfBlock)
         ->draw(
@@ -18,6 +17,4 @@ $display->draw(function (Buffer $buffer): void {
             // animating!
             ImageShape::fromFilename(__DIR__ . '/example.jpg')
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/line.php
+++ b/example/docs/shape/line.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -11,7 +10,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Line;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 20, 0, 20)
         ->marker(Marker::Dot)
         ->draw(Line::fromPrimitives(
@@ -21,6 +20,4 @@ $display->draw(function (Buffer $buffer): void {
             20, // y2
             AnsiColor::Green
         ))
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/map.php
+++ b/example/docs/shape/map.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -12,7 +11,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\MapResolution;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(-180, 180, -90, 90)
         ->marker(Marker::Braille)
         ->draw(
@@ -20,6 +19,4 @@ $display->draw(function (Buffer $buffer): void {
                 ->resolution(MapResolution::High)
                 ->color(AnsiColor::Green)
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/points.php
+++ b/example/docs/shape/points.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;

--- a/example/docs/shape/points.php
+++ b/example/docs/shape/points.php
@@ -11,7 +11,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Points;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 10, 0, 10)
         ->marker(Marker::Dot)
         ->draw(
@@ -23,6 +23,4 @@ $display->draw(function (Buffer $buffer): void {
                 [8, 8],
             ], AnsiColor::Black)
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/rectangle.php
+++ b/example/docs/shape/rectangle.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Widget\Canvas;
@@ -11,7 +10,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Rectangle;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 10, 0, 10)
         ->marker(Marker::Dot)
         ->draw(
@@ -23,6 +22,4 @@ $display->draw(function (Buffer $buffer): void {
                 AnsiColor::Green
             )
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/sprite.php
+++ b/example/docs/shape/sprite.php
@@ -2,7 +2,6 @@
 
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;
@@ -12,7 +11,7 @@ use PhpTui\Tui\Widget\Canvas\Shape\Sprite;
 require 'vendor/autoload.php';
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 20, 0, 10)
         ->marker(Marker::Braille)
         ->draw(
@@ -34,6 +33,4 @@ $display->draw(function (Buffer $buffer): void {
                 position: FloatPosition::at(0, 0),
             )
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/textShape.php
+++ b/example/docs/shape/textShape.php
@@ -17,7 +17,7 @@ require 'vendor/autoload.php';
 $registry = FontRegistry::default();
 
 $display = Display::fullscreen(PhpTermBackend::new());
-$display->draw(function (Buffer $buffer) use ($registry): void {
+$display->drawWidget(
     Canvas::fromIntBounds(0, 50, 0, 20)
         ->marker(Marker::Block)
         ->draw(
@@ -28,6 +28,4 @@ $display->draw(function (Buffer $buffer) use ($registry): void {
                 position: FloatPosition::at(10, 7),
             ),
         )
-        ->render($buffer->area(), $buffer);
-});
-$display->flush();
+);

--- a/example/docs/shape/textShape.php
+++ b/example/docs/shape/textShape.php
@@ -4,7 +4,6 @@ use PhpTui\Tui\Adapter\Bdf\FontRegistry;
 use PhpTui\Tui\Adapter\Bdf\Shape\TextShape;
 use PhpTui\Tui\Adapter\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;

--- a/example/docs/widget/block.php
+++ b/example/docs/widget/block.php
@@ -21,4 +21,3 @@ $display->draw(function (Buffer $buffer): void {
         ->widget(Paragraph::new(Text::raw('This is a block example')))
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/canvas.php
+++ b/example/docs/widget/canvas.php
@@ -26,4 +26,3 @@ $display->draw(function (Buffer $buffer): void {
         })
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/chart.php
+++ b/example/docs/widget/chart.php
@@ -48,4 +48,3 @@ $display->draw(function (Buffer $buffer): void {
         )
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/grid.php
+++ b/example/docs/widget/grid.php
@@ -35,4 +35,3 @@ $display->draw(function (Buffer $buffer): void {
         )
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/itemList.php
+++ b/example/docs/widget/itemList.php
@@ -23,4 +23,3 @@ $display->draw(function (Buffer $buffer): void {
         )
         ->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/paragraph.php
+++ b/example/docs/widget/paragraph.php
@@ -20,4 +20,3 @@ $display->draw(function (Buffer $buffer): void {
         )
     )->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/example/docs/widget/table.php
+++ b/example/docs/widget/table.php
@@ -44,4 +44,3 @@ $display->draw(function (Buffer $buffer): void {
             ]),
         )->render($buffer->area(), $buffer);
 });
-$display->flush();

--- a/src/Model/Display.php
+++ b/src/Model/Display.php
@@ -5,6 +5,8 @@ namespace PhpTui\Tui\Model;
 use Closure;
 use PhpTui\Tui\Model\Viewport\Fullscreen;
 use PhpTui\Tui\Model\Viewport\Inline;
+use PhpTui\Tui\Widget\Canvas\Shape;
+use PhpTui\Tui\Widget\Canvas\Shape\Points;
 
 final class Display
 {
@@ -57,6 +59,9 @@ final class Display
     }
 
     /**
+     * Synchronizes terminal size, calls the rendering closure, flushes the current internal state
+     * and prepares for the next draw call.
+     *
      * @param Closure(Buffer): void $closure
      */
     public function draw(Closure $closure): void
@@ -67,6 +72,21 @@ final class Display
         $this->flush();
         $this->swapBuffers();
         $this->backend->flush();
+    }
+
+    /**
+     * Synchronizes terminal size, renders the given widget, flushes the current internal state
+     * and prepares for the next draw call.
+     *
+     * This is the same as Draw but instead of a closure you pass a single
+     * widget (usually a Grid widget).
+     */
+    public function render(Widget $widget): void
+    {
+        $buffer = $this->buffer();
+        $this->draw(function () use ($widget, $buffer) {
+            $widget->render($buffer->area(), $buffer);
+        });
     }
 
     private function autoresize(): void

--- a/src/Model/Display.php
+++ b/src/Model/Display.php
@@ -81,7 +81,7 @@ final class Display
      * This is the same as Draw but instead of a closure you pass a single
      * widget (usually a Grid widget).
      */
-    public function render(Widget $widget): void
+    public function drawWidget(Widget $widget): void
     {
         $buffer = $this->buffer();
         $this->draw(function () use ($widget, $buffer) {

--- a/src/Model/Display.php
+++ b/src/Model/Display.php
@@ -5,8 +5,6 @@ namespace PhpTui\Tui\Model;
 use Closure;
 use PhpTui\Tui\Model\Viewport\Fullscreen;
 use PhpTui\Tui\Model\Viewport\Inline;
-use PhpTui\Tui\Widget\Canvas\Shape;
-use PhpTui\Tui\Widget\Canvas\Shape\Points;
 
 final class Display
 {
@@ -84,7 +82,7 @@ final class Display
     public function drawWidget(Widget $widget): void
     {
         $buffer = $this->buffer();
-        $this->draw(function () use ($widget, $buffer) {
+        $this->draw(function () use ($widget, $buffer): void {
             $widget->render($buffer->area(), $buffer);
         });
     }

--- a/tests/Model/DisplayTest.php
+++ b/tests/Model/DisplayTest.php
@@ -72,13 +72,12 @@ class DisplayTest extends TestCase
         ], AnsiColor::Green)));
 
         self::assertEquals(
-
             <<<'EOT'
-               •
-              • 
-             •  
-            •   
-            EOT,
+                   •
+                  • 
+                 •  
+                •   
+                EOT,
             $backend->flushed()
         );
     }

--- a/tests/Model/DisplayTest.php
+++ b/tests/Model/DisplayTest.php
@@ -67,7 +67,7 @@ class DisplayTest extends TestCase
     {
         $backend = DummyBackend::fromDimensions(4, 4);
         $terminal = Display::fullscreen($backend);
-        $terminal->render(Canvas::fromIntBounds(0, 3, 0, 3)->marker(Marker::Dot)->draw(Points::new([
+        $terminal->drawWidget(Canvas::fromIntBounds(0, 3, 0, 3)->marker(Marker::Dot)->draw(Points::new([
             [3, 3], [2, 2], [1, 1], [0, 0]
         ], AnsiColor::Green)));
 

--- a/tests/Model/DisplayTest.php
+++ b/tests/Model/DisplayTest.php
@@ -2,11 +2,15 @@
 
 namespace PhpTui\Tui\Tests\Model;
 
+use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Backend\DummyBackend;
 use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Display;
 use PHPUnit\Framework\TestCase;
+use PhpTui\Tui\Widget\Canvas;
+use PhpTui\Tui\Widget\Canvas\Shape\Points;
 
 class DisplayTest extends TestCase
 {
@@ -55,6 +59,26 @@ class DisplayTest extends TestCase
                   x 
                    x
                 EOT,
+            $backend->flushed()
+        );
+    }
+
+    public function testRender(): void
+    {
+        $backend = DummyBackend::fromDimensions(4, 4);
+        $terminal = Display::fullscreen($backend);
+        $terminal->render(Canvas::fromIntBounds(0, 3, 0, 3)->marker(Marker::Dot)->draw(Points::new([
+            [3, 3], [2, 2], [1, 1], [0, 0]
+        ], AnsiColor::Green)));
+
+        self::assertEquals(
+
+            <<<'EOT'
+               •
+              • 
+             •  
+            •   
+            EOT,
             $backend->flushed()
         );
     }


### PR DESCRIPTION
Now that we have a Grid widget all of the existing functionality can be achieved by using drawWidget(Widget) and not draw(Closure). I'm leaving the closure there for now (as with Ratatui) but could perhaps remove it in the future.