### PR TITLE
consistent use of `fromScalars` instead of incorrect `fromPrimitvies`

### DIFF
--- a/example/demo/src/Page/BlocksPage.php
+++ b/example/demo/src/Page/BlocksPage.php
@@ -194,7 +194,7 @@ class BlocksPage implements Component
         return Block::default()
             ->borders(Borders::ALL)
             ->titles(Title::fromString('padding'))
-            ->padding(Padding::fromInts(5, 10, 1, 2))
+            ->padding(Padding::fromScalars(5, 10, 1, 2))
             ->widget($paragraph);
     }
 

--- a/example/demo/src/Page/BlocksPage.php
+++ b/example/demo/src/Page/BlocksPage.php
@@ -194,7 +194,7 @@ class BlocksPage implements Component
         return Block::default()
             ->borders(Borders::ALL)
             ->titles(Title::fromString('padding'))
-            ->padding(Padding::fromPrimitives(5, 10, 1, 2))
+            ->padding(Padding::fromInts(5, 10, 1, 2))
             ->widget($paragraph);
     }
 

--- a/example/docs/shape/circle.php
+++ b/example/docs/shape/circle.php
@@ -13,5 +13,5 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->drawWidget(
     Canvas::fromIntBounds(-1, 21, -1, 21)
         ->marker(Marker::Dot)
-        ->draw(Circle::fromScalars(10, 10, 10, AnsiColor::Green))
+        ->draw(Circle::fromScalars(10, 10, 10)->color(AnsiColor::Green))
 );

--- a/example/docs/shape/circle.php
+++ b/example/docs/shape/circle.php
@@ -13,5 +13,5 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->drawWidget(
     Canvas::fromIntBounds(-1, 21, -1, 21)
         ->marker(Marker::Dot)
-        ->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green))
+        ->draw(Circle::fromScalars(10, 10, 10, AnsiColor::Green))
 );

--- a/example/docs/shape/line.php
+++ b/example/docs/shape/line.php
@@ -13,11 +13,10 @@ $display = Display::fullscreen(PhpTermBackend::new());
 $display->drawWidget(
     Canvas::fromIntBounds(0, 20, 0, 20)
         ->marker(Marker::Dot)
-        ->draw(Line::fromPrimitives(
+        ->draw(Line::fromScalars(
             0,  // x1
             0,  // y1
             20, // x2
             20, // y2
-            AnsiColor::Green
-        ))
+        )->color(AnsiColor::Green))
 );

--- a/example/docs/shape/rectangle.php
+++ b/example/docs/shape/rectangle.php
@@ -14,11 +14,12 @@ $display->drawWidget(
     Canvas::fromIntBounds(0, 10, 0, 10)
         ->marker(Marker::Dot)
         ->draw(
-            Rectangle::fromPrimitives(
+            Rectangle::fromScalars(
                 0,
                 0,
                 10,
                 10,
+            )->color(
                 AnsiColor::Green
             )
         )

--- a/example/docs/widget/canvas.php
+++ b/example/docs/widget/canvas.php
@@ -22,7 +22,7 @@ $display->draw(function (Buffer $buffer): void {
         // most cases
         ->paint(function (CanvasContext $context): void {
 
-            $context->draw(Circle::fromPrimitives(10, 10, 10, AnsiColor::Green));
+            $context->draw(Circle::fromScalars(10, 10, 10, AnsiColor::Green));
         })
         ->render($buffer->area(), $buffer);
 });

--- a/example/docs/widget/canvas.php
+++ b/example/docs/widget/canvas.php
@@ -22,7 +22,7 @@ $display->draw(function (Buffer $buffer): void {
         // most cases
         ->paint(function (CanvasContext $context): void {
 
-            $context->draw(Circle::fromScalars(10, 10, 10, AnsiColor::Green));
+            $context->draw(Circle::fromScalars(10, 10, 10)->color(AnsiColor::Green));
         })
         ->render($buffer->area(), $buffer);
 });

--- a/lib/bdf/src/BdfBoundingBox.php
+++ b/lib/bdf/src/BdfBoundingBox.php
@@ -13,7 +13,7 @@ class BdfBoundingBox
         return new self(new BdfSize(0, 0), new BdfCoord(0,0));
     }
 
-    public static function fromPrimitives(int $width, int $height, int $x, int $y): self
+    public static function fromScalars(int $width, int $height, int $x, int $y): self
     {
         return new self(new BdfSize($width, $height), new BdfCoord($x, $y));
     }

--- a/lib/bdf/src/BdfParser.php
+++ b/lib/bdf/src/BdfParser.php
@@ -225,7 +225,7 @@ final class BdfParser
             return null;
         }
         /** @phpstan-ignore-next-line */
-        $bbx = BdfBoundingBox::fromPrimitives($bbxWidth, $bbxHeight, $bbxX, $bbxY);
+        $bbx = BdfBoundingBox::fromScalars($bbxWidth, $bbxHeight, $bbxX, $bbxY);
 
         if (!$tokens->is('BITMAP')) {
             return null;

--- a/lib/bdf/tests/BdfParserTest.php
+++ b/lib/bdf/tests/BdfParserTest.php
@@ -61,7 +61,7 @@ class BdfParserTest extends TestCase
         self::assertEquals([
                 new BdfGlyph(
                     bitmap: [ 0x1f, 0x01 ],
-                    boundingBox: BdfBoundingBox::fromPrimitives(8, 8, 0, 0),
+                    boundingBox: BdfBoundingBox::fromScalars(8, 8, 0, 0),
                     encoding: 64,
                     name: 'Char 0',
                     deviceWidth: new BdfCoord(8, 0),
@@ -69,7 +69,7 @@ class BdfParserTest extends TestCase
                 ),
                 new BdfGlyph(
                     bitmap: [ 0x2f, 0x02 ],
-                    boundingBox: BdfBoundingBox::fromPrimitives(8, 8, 0, 0),
+                    boundingBox: BdfBoundingBox::fromScalars(8, 8, 0, 0),
                     encoding: 65,
                     name: 'Char 1',
                     deviceWidth: new BdfCoord(8, 0),

--- a/lib/term/src/Painter/HtmlStylePainter.php
+++ b/lib/term/src/Painter/HtmlStylePainter.php
@@ -97,7 +97,7 @@ class HtmlStylePainter implements Painter
                 continue;
             }
             if ($action instanceof Reset) {
-                $this->fgColor = null;
+                $this->fgColor = new SetRgbForegroundColor(0, 0, 0);
                 $this->bgColor = null;
                 continue;
             }

--- a/src/Adapter/Cassowary/CassowaryConstraintSolver.php
+++ b/src/Adapter/Cassowary/CassowaryConstraintSolver.php
@@ -81,13 +81,13 @@ final class CassowaryConstraintSolver implements ConstraintSolver
             $size = $end - $start;
 
             return match ($layout->direction) {
-                Direction::Horizontal => Area::fromPrimitives(
+                Direction::Horizontal => Area::fromScalars(
                     $start,
                     $inner->position->y,
                     $size,
                     $inner->height
                 ),
-                Direction::Vertical => Area::fromPrimitives(
+                Direction::Vertical => Area::fromScalars(
                     $inner->position->x,
                     $start,
                     $inner->width,

--- a/src/Model/Area.php
+++ b/src/Model/Area.php
@@ -18,7 +18,7 @@ final class Area implements Stringable
         return sprintf('@%s of %sx%s', $this->position->__toString(), $this->width, $this->height);
     }
 
-    public static function fromPrimitives(int $x, int $y, int $width, int $height): self
+    public static function fromScalars(int $x, int $y, int $width, int $height): self
     {
         return new self(new Position($x, $y), $width, $height);
     }
@@ -50,7 +50,7 @@ final class Area implements Stringable
 
     public static function fromDimensions(int $width, int $height): self
     {
-        return self::fromPrimitives(0, 0, $width, $height);
+        return self::fromScalars(0, 0, $width, $height);
     }
 
     public static function empty(): self
@@ -64,7 +64,7 @@ final class Area implements Stringable
             return self::empty();
         }
 
-        return self::fromPrimitives(
+        return self::fromScalars(
             $this->position->x + $margin->horizontal,
             $this->position->y + $margin->vertical,
             $this->width - 2 * $margin->horizontal,

--- a/src/Model/Backend/DummyBackend.php
+++ b/src/Model/Backend/DummyBackend.php
@@ -28,7 +28,7 @@ final class DummyBackend implements Backend
 
     public function size(): Area
     {
-        return Area::fromPrimitives(0, 0, $this->width, $this->height);
+        return Area::fromScalars(0, 0, $this->width, $this->height);
     }
 
     public function draw(BufferUpdates $updates): void

--- a/src/Model/Buffer.php
+++ b/src/Model/Buffer.php
@@ -65,7 +65,7 @@ final class Buffer implements Countable
             0
         );
 
-        $buffer = self::empty(Area::fromPrimitives(0, 0, $width, $height));
+        $buffer = self::empty(Area::fromScalars(0, 0, $width, $height));
         foreach ($lines as $y => $line) {
             $buffer->putString(new Position(0, $y), $line, Style::default());
         }

--- a/src/Widget/Block.php
+++ b/src/Widget/Block.php
@@ -160,7 +160,7 @@ final class Block implements Widget
         $width = $width - ($this->padding->left + $this->padding->right);
         $height = $height - ($this->padding->top + $this->padding->bottom);
 
-        return Area::fromPrimitives($x, $y, $width, $height);
+        return Area::fromScalars($x, $y, $width, $height);
     }
 
     private function renderBorders(Area $area, Buffer $buffer): void

--- a/src/Widget/Block/Padding.php
+++ b/src/Widget/Block/Padding.php
@@ -13,6 +13,11 @@ class Padding
         return new self(0, 0, 0, 0);
     }
 
+    public static function all(int $amount): self
+    {
+        return new self($amount, $amount, $amount, $amount);
+    }
+
     public static function fromInts(int $left, int $right, int $top, int $bottom): self
     {
         return new self($left, $right, $top, $bottom);

--- a/src/Widget/Block/Padding.php
+++ b/src/Widget/Block/Padding.php
@@ -18,7 +18,7 @@ class Padding
         return new self($amount, $amount, $amount, $amount);
     }
 
-    public static function fromInts(int $left, int $right, int $top, int $bottom): self
+    public static function fromScalars(int $left, int $right, int $top, int $bottom): self
     {
         return new self($left, $right, $top, $bottom);
     }

--- a/src/Widget/Block/Padding.php
+++ b/src/Widget/Block/Padding.php
@@ -13,7 +13,7 @@ class Padding
         return new self(0, 0, 0, 0);
     }
 
-    public static function fromPrimitives(int $left, int $right, int $top, int $bottom): self
+    public static function fromInts(int $left, int $right, int $top, int $bottom): self
     {
         return new self($left, $right, $top, $bottom);
     }

--- a/src/Widget/Canvas/Shape/Circle.php
+++ b/src/Widget/Canvas/Shape/Circle.php
@@ -2,6 +2,7 @@
 
 namespace PhpTui\Tui\Widget\Canvas\Shape;
 
+use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Widget\Canvas\Painter;
@@ -40,8 +41,8 @@ final class Circle implements Shape
         }
     }
 
-    public static function fromPrimitives(float $x, float $y, float $radius, Color $color): self
+    public static function fromScalars(float $x, float $y, float $radius): self
     {
-        return new self(FloatPosition::at($x, $y), $radius, $color);
+        return new self(FloatPosition::at($x, $y), $radius, AnsiColor::Reset);
     }
 }

--- a/src/Widget/Canvas/Shape/Circle.php
+++ b/src/Widget/Canvas/Shape/Circle.php
@@ -45,4 +45,10 @@ final class Circle implements Shape
     {
         return new self(FloatPosition::at($x, $y), $radius, AnsiColor::Reset);
     }
+
+    public function color(Color $color): self
+    {
+        $this->color = $color;
+        return $this;
+    }
 }

--- a/src/Widget/Canvas/Shape/Line.php
+++ b/src/Widget/Canvas/Shape/Line.php
@@ -2,6 +2,7 @@
 
 namespace PhpTui\Tui\Widget\Canvas\Shape;
 
+use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Widget\FloatPosition;
@@ -29,14 +30,19 @@ class Line implements Shape
     ) {
     }
 
-    public static function fromPrimitives(
+    public static function fromScalars(
         float $x1,
         float $y1,
         float $x2,
         float $y2,
-        Color $color
     ): self {
-        return new self(FloatPosition::at($x1, $y1), FloatPosition::at($x2, $y2), $color);
+        return new self(FloatPosition::at($x1, $y1), FloatPosition::at($x2, $y2), AnsiColor::Reset);
+    }
+
+    public function color(Color $color): self
+    {
+        $this->color = $color;
+        return $this;
     }
 
     public function draw(Painter $painter): void

--- a/src/Widget/Canvas/Shape/Map.php
+++ b/src/Widget/Canvas/Shape/Map.php
@@ -13,7 +13,7 @@ use PhpTui\Tui\Widget\Canvas\Shape;
  */
 class Map implements Shape
 {
-    private function __construct(
+    public function __construct(
         /**
          * Resolution of the map (enum low or high)
          */

--- a/src/Widget/Canvas/Shape/Rectangle.php
+++ b/src/Widget/Canvas/Shape/Rectangle.php
@@ -2,6 +2,7 @@
 
 namespace PhpTui\Tui\Widget\Canvas\Shape;
 
+use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Widget\Canvas\Painter;
@@ -66,8 +67,14 @@ final class Rectangle implements Shape
         }
     }
 
-    public static function fromPrimitives(float $x, float $y, int $width, int $height, Color $color): self
+    public static function fromScalars(float $x, float $y, int $width, int $height): self
     {
-        return new self(FloatPosition::at($x, $y), $width, $height, $color);
+        return new self(FloatPosition::at($x, $y), $width, $height, AnsiColor::Reset);
+    }
+
+    public function color(Color $color): self
+    {
+        $this->color = $color;
+        return $this;
     }
 }

--- a/src/Widget/Canvas/Shape/Rectangle.php
+++ b/src/Widget/Canvas/Shape/Rectangle.php
@@ -35,34 +35,30 @@ final class Rectangle implements Shape
     public function draw(Painter $painter): void
     {
         $lines = [
-            Line::fromPrimitives(
+            Line::fromScalars(
                 $this->position->x,
                 $this->position->y,
                 $this->position->x,
                 $this->position->y + $this->height,
-                $this->color
-            ),
-            Line::fromPrimitives(
+            )->color($this->color),
+            Line::fromScalars(
                 $this->position->x,
                 $this->position->y + $this->height,
                 $this->position->x + $this->width,
                 $this->position->y + $this->height,
-                $this->color
-            ),
-            Line::fromPrimitives(
+            )->color($this->color),
+            Line::fromScalars(
                 $this->position->x + $this->width,
                 $this->position->y,
                 $this->position->x + $this->width,
                 $this->position->y + $this->height,
-                $this->color
-            ),
-            Line::fromPrimitives(
+            )->color($this->color),
+            Line::fromScalars(
                 $this->position->x,
                 $this->position->y,
                 $this->position->x + $this->width,
                 $this->position->y,
-                $this->color
-            ),
+            )->color($this->color),
         ];
 
         foreach ($lines as $line) {

--- a/src/Widget/Chart.php
+++ b/src/Widget/Chart.php
@@ -155,7 +155,7 @@ final class Chart implements Widget
             $x += 1;
         }
 
-        $graphArea = Area::fromPrimitives(
+        $graphArea = Area::fromScalars(
             $x,
             $area->top(),
             $area->right() - $x,
@@ -220,11 +220,11 @@ final class Chart implements Widget
         }
         foreach ($labels as $i => $label) {
             $x = $layout->graphArea->left() + ($i + 1) * $widthBetweenTicks + 1;
-            $labelArea = Area::fromPrimitives($x, $layout->labelX, $widthBetweenTicks -1, 1);
+            $labelArea = Area::fromScalars($x, $layout->labelX, $widthBetweenTicks -1, 1);
             $this->renderLabel($buffer, $label, $labelArea, HorizontalAlignment::Center);
         }
         $x = $layout->graphArea->right() - $widthBetweenTicks;
-        $labelArea = Area::fromPrimitives($x, $layout->labelX, $widthBetweenTicks, 1);
+        $labelArea = Area::fromScalars($x, $layout->labelX, $widthBetweenTicks, 1);
         $this->renderLabel($buffer, $lastLabel, $labelArea, HorizontalAlignment::Center);
 
     }
@@ -240,7 +240,7 @@ final class Chart implements Widget
             ],
         };
 
-        return Area::fromPrimitives($minX, $y, $maxX - $minX, 1);
+        return Area::fromScalars($minX, $y, $maxX - $minX, 1);
     }
 
     private function renderLabel(Buffer $buffer, Span $label, Area $labelArea, HorizontalAlignment $labelAlignment): void
@@ -268,7 +268,7 @@ final class Chart implements Widget
         foreach ($labels as $i => $label) {
             $dy = intval($i * ($layout->graphArea->height - 1) / ($labelsLen - 1));
             if ($dy < $layout->graphArea->bottom()) {
-                $labelArea = Area::fromPrimitives(
+                $labelArea = Area::fromScalars(
                     $layout->labelY,
                     max(0, $layout->graphArea->bottom() - 1 - $dy),
                     max(0, ($layout->graphArea->left() - $chartArea->left()) - 1),

--- a/src/Widget/ItemList.php
+++ b/src/Widget/ItemList.php
@@ -64,7 +64,7 @@ class ItemList implements Widget
                 return [$listArea->left(), $y, $currentHeight];
             })();
 
-            $area = Area::fromPrimitives($x, $y, $listArea->width, $item->height());
+            $area = Area::fromScalars($x, $y, $listArea->width, $item->height());
             $itemStyle = $this->style->patch($item->style);
             $buffer->setStyle($area, $itemStyle);
 

--- a/src/Widget/Table.php
+++ b/src/Widget/Table.php
@@ -83,7 +83,7 @@ final class Table implements Widget
         if ($header !== null) {
             $maxHeaderHight = min($tableArea->height, $header->totalHeight());
             $buffer->setStyle(
-                Area::fromPrimitives(
+                Area::fromScalars(
                     $tableArea->left(),
                     $tableArea->top(),
                     $tableArea->width,
@@ -100,7 +100,7 @@ final class Table implements Widget
                 $this->renderCell(
                     $buffer,
                     $cell,
-                    Area::fromPrimitives(
+                    Area::fromScalars(
                         $innerOffset + $width[0],
                         $tableArea->top(),
                         $width[1],
@@ -121,7 +121,7 @@ final class Table implements Widget
             [$rowY, $innerOffset] = [$tableArea->top() + $currentHeight, $tableArea->left()];
 
             $currentHeight += $tableRow->totalHeight();
-            $tableRowArea = Area::fromPrimitives($innerOffset, $rowY, $tableArea->width, $tableRow->height);
+            $tableRowArea = Area::fromScalars($innerOffset, $rowY, $tableArea->width, $tableRow->height);
             $buffer->setStyle($tableRowArea, $tableRow->style);
             $isSelected = $this->state->selected === $i + $start;
             if ($selectionWidth > 0 && $isSelected) {
@@ -143,7 +143,7 @@ final class Table implements Widget
                 $this->renderCell(
                     $buffer,
                     $cell,
-                    Area::fromPrimitives(
+                    Area::fromScalars(
                         $innerOffset + $width[0],
                         $rowY,
                         $width[1],

--- a/tests/Model/AreaTest.php
+++ b/tests/Model/AreaTest.php
@@ -16,6 +16,6 @@ class AreaTest extends TestCase
     public function testInner(): void
     {
         $a = Area::fromDimensions(10, 10);
-        self::assertEquals(Area::fromPrimitives(2, 2, 6, 6), $a->inner(new Margin(2, 2)));
+        self::assertEquals(Area::fromScalars(2, 2, 6, 6), $a->inner(new Margin(2, 2)));
     }
 }

--- a/tests/Model/BufferTest.php
+++ b/tests/Model/BufferTest.php
@@ -18,13 +18,13 @@ class BufferTest extends TestCase
 {
     public function testEmpty(): void
     {
-        $buffer = Buffer::empty(Area::fromPrimitives(0, 0, 100, 100));
+        $buffer = Buffer::empty(Area::fromScalars(0, 0, 100, 100));
         self::assertCount(10000, $buffer);
     }
 
     public function testFilled(): void
     {
-        $buffer = Buffer::filled(Area::fromPrimitives(0, 0, 10, 10), Cell::fromChar('X'));
+        $buffer = Buffer::filled(Area::fromScalars(0, 0, 10, 10), Cell::fromChar('X'));
         self::assertCount(100, $buffer);
         self::assertEquals(array_fill(0, 100, Cell::fromChar('X')), $buffer->content());
         self::assertNotSame($buffer->get(Position::at(0, 0))->modifier, $buffer->get(Position::at(1, 1))->modifier, 'cells are propertly cloned!');
@@ -51,7 +51,7 @@ class BufferTest extends TestCase
             '1234',
             '1234',
         ]);
-        $buffer->setStyle(Area::fromPrimitives(1, 1, 2, 2), Style::default()->fg(AnsiColor::Red));
+        $buffer->setStyle(Area::fromScalars(1, 1, 2, 2), Style::default()->fg(AnsiColor::Red));
 
         self::assertEquals(AnsiColor::Reset, $buffer->get(Position::at(0, 0))->fg);
         self::assertEquals(AnsiColor::Red, $buffer->get(Position::at(1, 1))->fg);

--- a/tests/Model/LayoutTest.php
+++ b/tests/Model/LayoutTest.php
@@ -12,7 +12,7 @@ class LayoutTest extends TestCase
 {
     public function testVerticalSplitByHeight(): void
     {
-        $target = Area::fromPrimitives(2, 2, 10, 10);
+        $target = Area::fromScalars(2, 2, 10, 10);
         $chunks = Layout::default()
             ->direction(Direction::Vertical)
             ->constraints([
@@ -35,7 +35,7 @@ class LayoutTest extends TestCase
 
     public function testSplitEquallyInUnderspecifiedCase(): void
     {
-        $target = Area::fromPrimitives(100, 100, 10, 10);
+        $target = Area::fromScalars(100, 100, 10, 10);
         $layout = Layout::default()
             ->direction(Direction::Horizontal)
             ->constraints([

--- a/tests/Model/PositionTest.php
+++ b/tests/Model/PositionTest.php
@@ -12,7 +12,7 @@ class PositionTest extends TestCase
     {
         self::assertEquals(
             55,
-            (new Position(5, 5))->toIndex(Area::fromPrimitives(0, 0, 10, 10))
+            (new Position(5, 5))->toIndex(Area::fromScalars(0, 0, 10, 10))
         );
     }
 
@@ -21,13 +21,13 @@ class PositionTest extends TestCase
         $this->expectExceptionMessage('Position (15,5) outside of area @(0,0) of 10x10 when trying to get index');
         self::assertEquals(
             55,
-            (new Position(15, 5))->toIndex(Area::fromPrimitives(0, 0, 10, 10))
+            (new Position(15, 5))->toIndex(Area::fromScalars(0, 0, 10, 10))
         );
     }
 
     public function testCreatesPositionFromIndex(): void
     {
-        $position = Position::fromIndex(55, Area::fromPrimitives(0, 0, 10, 10));
+        $position = Position::fromIndex(55, Area::fromScalars(0, 0, 10, 10));
         self::assertEquals(5, $position->x);
         self::assertEquals(5, $position->y);
     }
@@ -35,6 +35,6 @@ class PositionTest extends TestCase
     public function testThrowsExceptionIfIndexOutOfRange(): void
     {
         $this->expectExceptionMessage('outside of area');
-        Position::fromIndex(100, Area::fromPrimitives(0, 0, 10, 10));
+        Position::fromIndex(100, Area::fromScalars(0, 0, 10, 10));
     }
 }

--- a/tests/Widget/Block/PaddingTest.php
+++ b/tests/Widget/Block/PaddingTest.php
@@ -16,4 +16,3 @@ class PaddingTest extends TestCase
         self::assertEquals(2, $all->right);
     }
 }
-

--- a/tests/Widget/Block/PaddingTest.php
+++ b/tests/Widget/Block/PaddingTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PhpTui\Tui\Tests\Widget\Block;
+
+use PHPUnit\Framework\TestCase;
+use PhpTui\Tui\Widget\Block\Padding;
+
+class PaddingTest extends TestCase
+{
+    public function testAll(): void
+    {
+        $all = Padding::all(2);
+        self::assertEquals(2, $all->top);
+        self::assertEquals(2, $all->bottom);
+        self::assertEquals(2, $all->left);
+        self::assertEquals(2, $all->right);
+    }
+}
+

--- a/tests/Widget/BlockTest.php
+++ b/tests/Widget/BlockTest.php
@@ -295,7 +295,7 @@ class BlockTest extends TestCase
         $block = Block::default()
             ->borderType(BorderType::Rounded)
             ->borders(Borders::ALL)
-            ->padding(Padding::fromInts(1, 1, 1, 1));
+            ->padding(Padding::fromScalars(1, 1, 1, 1));
 
         Paragraph::fromText(Text::fromString('Foob'))->render($block->inner($buffer->area()), $buffer);
         $block->render($buffer->area(), $buffer);

--- a/tests/Widget/BlockTest.php
+++ b/tests/Widget/BlockTest.php
@@ -35,8 +35,8 @@ class BlockTest extends TestCase
             Block::default(),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 0, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 0, 0))
+                    Area::fromScalars(0, 0, 0, 0),
+                    $block->inner(Area::fromScalars(0, 0, 0, 0))
                 );
             }
         ];
@@ -44,8 +44,8 @@ class BlockTest extends TestCase
             Block::default(),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 1, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 1))
+                    Area::fromScalars(0, 0, 1, 1),
+                    $block->inner(Area::fromScalars(0, 0, 1, 1))
                 );
             }
         ];
@@ -53,8 +53,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::LEFT),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 0, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 0, 1))
+                    Area::fromScalars(0, 0, 0, 1),
+                    $block->inner(Area::fromScalars(0, 0, 0, 1))
                 );
             }
         ];
@@ -62,8 +62,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::LEFT),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(1, 0, 0, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 1))
+                    Area::fromScalars(1, 0, 0, 1),
+                    $block->inner(Area::fromScalars(0, 0, 1, 1))
                 );
             }
         ];
@@ -71,8 +71,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::LEFT),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(1, 0, 1, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 2, 1))
+                    Area::fromScalars(1, 0, 1, 1),
+                    $block->inner(Area::fromScalars(0, 0, 2, 1))
                 );
             }
         ];
@@ -80,8 +80,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::TOP),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 1, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 0))
+                    Area::fromScalars(0, 0, 1, 0),
+                    $block->inner(Area::fromScalars(0, 0, 1, 0))
                 );
             }
         ];
@@ -89,8 +89,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::TOP),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 1, 1, 0),
-                    $block->inner(Area::fromPrimitives(0, 1, 1, 0))
+                    Area::fromScalars(0, 1, 1, 0),
+                    $block->inner(Area::fromScalars(0, 1, 1, 0))
                 );
             }
         ];
@@ -98,8 +98,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::TOP),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 1, 1, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 2))
+                    Area::fromScalars(0, 1, 1, 1),
+                    $block->inner(Area::fromScalars(0, 0, 1, 2))
                 );
             }
         ];
@@ -107,8 +107,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::RIGHT),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 0, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 0, 1))
+                    Area::fromScalars(0, 0, 0, 1),
+                    $block->inner(Area::fromScalars(0, 0, 0, 1))
                 );
             }
         ];
@@ -116,8 +116,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::RIGHT),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 0, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 1))
+                    Area::fromScalars(0, 0, 0, 1),
+                    $block->inner(Area::fromScalars(0, 0, 1, 1))
                 );
             }
         ];
@@ -125,8 +125,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::RIGHT),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 1, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 2, 1))
+                    Area::fromScalars(0, 0, 1, 1),
+                    $block->inner(Area::fromScalars(0, 0, 2, 1))
                 );
             }
         ];
@@ -134,8 +134,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::BOTTOM),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 1, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 0))
+                    Area::fromScalars(0, 0, 1, 0),
+                    $block->inner(Area::fromScalars(0, 0, 1, 0))
                 );
             }
         ];
@@ -143,8 +143,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::BOTTOM),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 1, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 1))
+                    Area::fromScalars(0, 0, 1, 0),
+                    $block->inner(Area::fromScalars(0, 0, 1, 1))
                 );
             }
         ];
@@ -152,8 +152,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::BOTTOM),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 1, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 2))
+                    Area::fromScalars(0, 0, 1, 1),
+                    $block->inner(Area::fromScalars(0, 0, 1, 2))
                 );
             }
         ];
@@ -161,8 +161,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::ALL),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 0, 0, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 0, 0))
+                    Area::fromScalars(0, 0, 0, 0),
+                    $block->inner(Area::fromScalars(0, 0, 0, 0))
                 );
             }
         ];
@@ -170,8 +170,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::ALL),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(1, 1, 0, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 1, 1))
+                    Area::fromScalars(1, 1, 0, 0),
+                    $block->inner(Area::fromScalars(0, 0, 1, 1))
                 );
             }
         ];
@@ -179,8 +179,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::ALL),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(1, 1, 0, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 2, 2))
+                    Area::fromScalars(1, 1, 0, 0),
+                    $block->inner(Area::fromScalars(0, 0, 2, 2))
                 );
             }
         ];
@@ -188,8 +188,8 @@ class BlockTest extends TestCase
             Block::default()->borders(Borders::ALL),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(1, 1, 1, 1),
-                    $block->inner(Area::fromPrimitives(0, 0, 3, 3))
+                    Area::fromScalars(1, 1, 1, 1),
+                    $block->inner(Area::fromScalars(0, 0, 3, 3))
                 );
             }
         ];
@@ -197,8 +197,8 @@ class BlockTest extends TestCase
             Block::default()->titles(Title::fromString('Hello World')),
             function (Block $block): void {
                 self::assertEquals(
-                    Area::fromPrimitives(0, 1, 0, 0),
-                    $block->inner(Area::fromPrimitives(0, 0, 0, 1))
+                    Area::fromScalars(0, 1, 0, 0),
+                    $block->inner(Area::fromScalars(0, 0, 0, 1))
                 );
             }
         ];

--- a/tests/Widget/BlockTest.php
+++ b/tests/Widget/BlockTest.php
@@ -295,7 +295,7 @@ class BlockTest extends TestCase
         $block = Block::default()
             ->borderType(BorderType::Rounded)
             ->borders(Borders::ALL)
-            ->padding(Padding::fromPrimitives(1, 1, 1, 1));
+            ->padding(Padding::fromInts(1, 1, 1, 1));
 
         Paragraph::fromText(Text::fromString('Foob'))->render($block->inner($buffer->area()), $buffer);
         $block->render($buffer->area(), $buffer);

--- a/tests/Widget/Canvas/Shape/CircleTest.php
+++ b/tests/Widget/Canvas/Shape/CircleTest.php
@@ -39,7 +39,7 @@ class CircleTest extends TestCase
     public static function provideCircle(): Generator
     {
         yield 'circle' => [
-            Circle::fromPrimitives(5, 2, 5, AnsiColor::Reset),
+            Circle::fromScalars(5, 2, 5, AnsiColor::Reset),
             [
             '     ⢀⣠⢤⣀ ',
             '    ⢰⠋  ⠈⣇',

--- a/tests/Widget/Canvas/Shape/CircleTest.php
+++ b/tests/Widget/Canvas/Shape/CircleTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpTui\Tui\Tests\Widget\Canvas\Shape;
 
-use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
@@ -39,7 +38,7 @@ class CircleTest extends TestCase
     public static function provideCircle(): Generator
     {
         yield 'circle' => [
-            Circle::fromScalars(5, 2, 5, AnsiColor::Reset),
+            Circle::fromScalars(5, 2, 5),
             [
             '     ⢀⣠⢤⣀ ',
             '    ⢰⠋  ⠈⣇',

--- a/tests/Widget/Canvas/Shape/LineTest.php
+++ b/tests/Widget/Canvas/Shape/LineTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpTui\Tui\Tests\Widget\Canvas\Shape;
 
-use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
@@ -39,7 +38,7 @@ class LineTest extends TestCase
     public static function provideLine(): Generator
     {
         yield 'out of bounds' => [
-            Line::fromPrimitives(-1.0, -1.0, 10.0, 10.0, AnsiColor::Red),
+            Line::fromScalars(-1.0, -1.0, 10.0, 10.0),
             [
                 '          ',
                 '          ',
@@ -55,7 +54,7 @@ class LineTest extends TestCase
         ];
 
         yield 'horizontal' => [
-            Line::fromPrimitives(0.0, 0.0, 10.0, 0.0, AnsiColor::Red),
+            Line::fromScalars(0.0, 0.0, 10.0, 0.0),
             [
                 '          ',
                 '          ',
@@ -70,7 +69,7 @@ class LineTest extends TestCase
             ]
         ];
         yield 'horizontal 2' => [
-            Line::fromPrimitives(10.0, 10.0, 0.0, 10.0, AnsiColor::Red),
+            Line::fromScalars(10.0, 10.0, 0.0, 10.0),
             [
                 '••••••••••',
                 '          ',
@@ -86,7 +85,7 @@ class LineTest extends TestCase
         ];
 
         yield 'vertical' => [
-            Line::fromPrimitives(0.0, 0.0, 0.0, 10.0, AnsiColor::Red),
+            Line::fromScalars(0.0, 0.0, 0.0, 10.0),
             [
                 '•         ',
                 '•         ',
@@ -101,7 +100,7 @@ class LineTest extends TestCase
             ]
         ];
         yield 'diagonal' => [
-            Line::fromPrimitives(0.0, 0.0, 10.0, 5.0, AnsiColor::Red),
+            Line::fromScalars(0.0, 0.0, 10.0, 5.0),
             [
                 '          ',
                 '          ',
@@ -116,7 +115,7 @@ class LineTest extends TestCase
             ]
         ];
         yield 'diagonal dy > dx, y1 < y2' => [
-            Line::fromPrimitives(0.0, 0.0, 5.0, 10.0, AnsiColor::Red),
+            Line::fromScalars(0.0, 0.0, 5.0, 10.0),
             [
                 '    •     ',
                 '    •     ',
@@ -131,7 +130,7 @@ class LineTest extends TestCase
             ]
         ];
         yield 'diagonal dy < dx, x1 < x2' => [
-            Line::fromPrimitives(10.0, 0.0, 0.0, 5.0, AnsiColor::Red),
+            Line::fromScalars(10.0, 0.0, 0.0, 5.0),
             [
                 '          ',
                 '          ',
@@ -146,7 +145,7 @@ class LineTest extends TestCase
             ]
         ];
         yield 'diagonal dy > dx, y1 > y2' => [
-            Line::fromPrimitives(0.0, 10.0, 5.0, 0.0, AnsiColor::Red),
+            Line::fromScalars(0.0, 10.0, 5.0, 0.0),
             [
                 '•         ',
                 '•         ',

--- a/tests/Widget/Canvas/Shape/RectangleTest.php
+++ b/tests/Widget/Canvas/Shape/RectangleTest.php
@@ -39,7 +39,7 @@ class RectangleTest extends TestCase
     public static function provideRectangle(): Generator
     {
         yield 'circle' => [
-            Rectangle::fromPrimitives(0, 0, 10, 10, AnsiColor::Reset),
+            Rectangle::fromScalars(0, 0, 10, 10)->color(AnsiColor::Reset),
             [
             '██████████',
             '█        █',

--- a/tests/Widget/CanvasTest.php
+++ b/tests/Widget/CanvasTest.php
@@ -31,7 +31,7 @@ class CanvasTest extends TestCase
         $buffer = Buffer::filled($area, Cell::fromChar('x'));
 
         $canvas = Canvas::fromIntBounds(0, 10, 0, 10);
-        $canvas->draw(Circle::fromPrimitives(5, 5, 5, AnsiColor::Green));
+        $canvas->draw(Circle::fromScalars(5, 5, 5, AnsiColor::Green));
         $canvas->render($area, $buffer);
         $expected = [
             'x⢀⡴⠋⠉⠉⠳⣄xx',
@@ -59,8 +59,8 @@ class CanvasTest extends TestCase
 
         $canvas = Canvas::fromIntBounds(0, 5, 0, 5);
         $canvas->draw(
-            Circle::fromPrimitives(1, 1, 1, AnsiColor::Green),
-            Circle::fromPrimitives(4, 4, 1, AnsiColor::Green),
+            Circle::fromScalars(1, 1, 1, AnsiColor::Green),
+            Circle::fromScalars(4, 4, 1, AnsiColor::Green),
         );
         $canvas->render($area, $buffer);
         $expected = [

--- a/tests/Widget/CanvasTest.php
+++ b/tests/Widget/CanvasTest.php
@@ -31,7 +31,7 @@ class CanvasTest extends TestCase
         $buffer = Buffer::filled($area, Cell::fromChar('x'));
 
         $canvas = Canvas::fromIntBounds(0, 10, 0, 10);
-        $canvas->draw(Circle::fromScalars(5, 5, 5, AnsiColor::Green));
+        $canvas->draw(Circle::fromScalars(5, 5, 5)->color(AnsiColor::Green));
         $canvas->render($area, $buffer);
         $expected = [
             'x⢀⡴⠋⠉⠉⠳⣄xx',
@@ -59,8 +59,8 @@ class CanvasTest extends TestCase
 
         $canvas = Canvas::fromIntBounds(0, 5, 0, 5);
         $canvas->draw(
-            Circle::fromScalars(1, 1, 1, AnsiColor::Green),
-            Circle::fromScalars(4, 4, 1, AnsiColor::Green),
+            Circle::fromScalars(1, 1, 1),
+            Circle::fromScalars(4, 4, 1),
         );
         $canvas->render($area, $buffer);
         $expected = [

--- a/tests/Widget/CanvasTest.php
+++ b/tests/Widget/CanvasTest.php
@@ -79,18 +79,20 @@ class CanvasTest extends TestCase
      */
     public function testRenderMarker(Marker $marker, array $expected): void
     {
-        $horizontalLine = Line::fromPrimitives(
+        $horizontalLine = Line::fromScalars(
             0.0,
             0.0,
             10.0,
             0.0,
+        )->color(
             AnsiColor::Green
         );
-        $verticalLine = Line::fromPrimitives(
+        $verticalLine = Line::fromScalars(
             0.0,
             0.0,
             0.0,
             10.0,
+        )->color(
             AnsiColor::Green
         );
         $canvas = Canvas::default()->paint(

--- a/tests/Widget/CanvasTest.php
+++ b/tests/Widget/CanvasTest.php
@@ -101,7 +101,7 @@ class CanvasTest extends TestCase
                 $context->draw($horizontalLine);
             }
         )->xBounds(AxisBounds::new(0.0, 10.0))->yBounds(AxisBounds::new(0.0, 10.0))->marker($marker);
-        $area = Area::fromPrimitives(0, 0, 5, 5);
+        $area = Area::fromScalars(0, 0, 5, 5);
         $buffer = Buffer::filled($area, Cell::fromChar('x'));
         $canvas->render($area, $buffer);
         self::assertEquals($expected, $buffer->toLines());
@@ -170,7 +170,7 @@ class CanvasTest extends TestCase
                 $context->print(0, 0, DTLLine::fromString('Hello'));
             }
         )->xBounds(AxisBounds::new(0.0, 10.0))->yBounds(AxisBounds::new(0.0, 5));
-        $area = Area::fromPrimitives(0, 0, 5, 5);
+        $area = Area::fromScalars(0, 0, 5, 5);
         $buffer = Buffer::empty($area);
         $canvas->render($area, $buffer);
         self::assertEquals([

--- a/tests/Widget/ParagraphTest.php
+++ b/tests/Widget/ParagraphTest.php
@@ -27,7 +27,7 @@ class ParagraphTest extends TestCase
             Line::fromString('Hello'),
             Line::fromString('Goodbye'),
         ), $paragraph);
-        $area = Area::fromPrimitives(0, 0, 10, 2);
+        $area = Area::fromScalars(0, 0, 10, 2);
         $buffer = Buffer::empty($area);
         $paragraph->render($buffer->area(), $buffer);
         self::assertEquals([

--- a/tests/Widget/RawWidgetTest.php
+++ b/tests/Widget/RawWidgetTest.php
@@ -56,7 +56,7 @@ class RawWidgetTest extends TestCase
                 RawWidget::new(function (Buffer $buffer): void {
                     $buffer->putLine(Position::at(0, 0), Line::fromString('Hello'), 5);
                 })
-            )->padding(Padding::fromPrimitives(1, 1, 1, 1)),
+            )->padding(Padding::fromInts(1, 1, 1, 1)),
             [
                 '          ',
                 ' Hello    ',
@@ -77,7 +77,7 @@ class RawWidgetTest extends TestCase
                 RawWidget::new(function (Buffer $buffer): void {
                     $buffer->putSpan(Position::at(0, 0), Span::fromString(str_repeat('Hello', 10)), 10);
                 })
-            )->padding(Padding::fromPrimitives(1, 1, 1, 1)),
+            )->padding(Padding::fromInts(1, 1, 1, 1)),
             [
                 '          ',
                 ' HelloHel ',

--- a/tests/Widget/RawWidgetTest.php
+++ b/tests/Widget/RawWidgetTest.php
@@ -56,7 +56,7 @@ class RawWidgetTest extends TestCase
                 RawWidget::new(function (Buffer $buffer): void {
                     $buffer->putLine(Position::at(0, 0), Line::fromString('Hello'), 5);
                 })
-            )->padding(Padding::fromInts(1, 1, 1, 1)),
+            )->padding(Padding::fromScalars(1, 1, 1, 1)),
             [
                 '          ',
                 ' Hello    ',
@@ -77,7 +77,7 @@ class RawWidgetTest extends TestCase
                 RawWidget::new(function (Buffer $buffer): void {
                     $buffer->putSpan(Position::at(0, 0), Span::fromString(str_repeat('Hello', 10)), 10);
                 })
-            )->padding(Padding::fromInts(1, 1, 1, 1)),
+            )->padding(Padding::fromScalars(1, 1, 1, 1)),
             [
                 '          ',
                 ' HelloHel ',


### PR DESCRIPTION
`fromPrimitives` was being used with f.e. `Color` which is not a primitive

- Remove non-scalar values from fromPrimitives
- Rename to `fromScalars` as it's shorter