### PR TITLE
Perf: Pre-cache Braille chars

### DIFF
--- a/src/Model/Widget/BrailleSet.php
+++ b/src/Model/Widget/BrailleSet.php
@@ -4,6 +4,8 @@ namespace PhpTui\Tui\Model\Widget;
 
 final class BrailleSet
 {
+    // Braille patterns range from U+2800 to U+28FF
+    public const RANGE = [0x2800, 0x28FF];
     public const BLANK = 0x2800;
     public const DOTS = [
         [0x0001, 0x0008],


### PR DESCRIPTION
With this change, we avoid calling `IntlChar::chr()` more than 1 million times in a short period, so we can gain some cpu cycles.

![image](https://github.com/php-tui/php-tui/assets/999232/e66356c2-78de-4335-ac17-be38da87c1d0)
