### PR TITLE
Perf: improve `BdfTokenStream` logic

### DIFF
--- a/lib/bdf/src/BdfTokenStream.php
+++ b/lib/bdf/src/BdfTokenStream.php
@@ -54,7 +54,7 @@ final class BdfTokenStream
     public function parseLine(): string
     {
         $taken = $this->takeWhile(
-            static fn (string $token): bool => $token !== PHP_EOL
+            static fn (string $token): bool => $token !== "\n"
         );
         $this->skipWhitespace();
         $this->skipComments();

--- a/lib/bdf/tests/Benchmark/BdfParserBench.php
+++ b/lib/bdf/tests/Benchmark/BdfParserBench.php
@@ -11,16 +11,21 @@ use PhpBench\Attributes\Revs;
 #[Revs(25)]
 final class BdfParserBench
 {
-    public function benchParseRealFont(): void
+    private string $contents;
+
+    public function __construct()
     {
         $contents = file_get_contents(__DIR__ . '/../../fonts/6x10.bdf');
 
         if (false === $contents) {
-            throw new RuntimeException(
-                'Could not read file'
-            );
+            throw new RuntimeException('Could not read file');
         }
 
-        (new BdfParser())->parse($contents);
+        $this->contents = $contents;
+    }
+
+    public function benchParseRealFont(): void
+    {
+        (new BdfParser())->parse($this->contents);
     }
 }

--- a/lib/bdf/tests/Benchmark/BdfParserBench.php
+++ b/lib/bdf/tests/Benchmark/BdfParserBench.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpTui\Bdf\Tests\Benchmark;
+
+use RuntimeException;
+use PhpTui\BDF\BdfParser;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+
+#[Iterations(10)]
+#[Revs(25)]
+final class BdfParserBench
+{
+    public function benchParseRealFont(): void
+    {
+        $contents = file_get_contents(__DIR__ . '/../../fonts/6x10.bdf');
+
+        if (false === $contents) {
+            throw new RuntimeException(
+                'Could not read file'
+            );
+        }
+
+        (new BdfParser())->parse($contents);
+    }
+}

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,5 +1,8 @@
 {
-    "runner.path": "tests/Benchmark",
-    "$schema": "vendor/phpbench/phpbench/phpbench.schema.json",
-    "runner.bootstrap": "vendor/autoload.php"
+  "runner.path": [
+    "tests/Benchmark",
+    "lib/bdf/tests/Benchmark"
+  ],
+  "$schema": "vendor/phpbench/phpbench/phpbench.schema.json",
+  "runner.bootstrap": "vendor/autoload.php"
 }


### PR DESCRIPTION
Key changes:

- Introduced a new method `skipWhile()` that doesn't make new allocations (unlike `takeWhile()`, which does with `$taken`).
- One fewer call to `$this->current()` in `takeWhile()` on every iteration.