### PR TITLE
Bdf parser: Add `BdfToken` Enum and some code style changes

### DIFF
--- a/lib/bdf/src/BdfBoundingBox.php
+++ b/lib/bdf/src/BdfBoundingBox.php
@@ -2,10 +2,12 @@
 
 namespace PhpTui\BDF;
 
-class BdfBoundingBox
+final class BdfBoundingBox
 {
-    public function __construct(public BdfSize $size, public BdfCoord $offset)
-    {
+    public function __construct(
+        public readonly BdfSize $size,
+        public readonly BdfCoord $offset
+    ) {
     }
 
     public static function empty(): self
@@ -17,5 +19,4 @@ class BdfBoundingBox
     {
         return new self(new BdfSize($width, $height), new BdfCoord($x, $y));
     }
-
 }

--- a/lib/bdf/src/BdfCoord.php
+++ b/lib/bdf/src/BdfCoord.php
@@ -2,12 +2,11 @@
 
 namespace PhpTui\BDF;
 
-class BdfCoord
+final class BdfCoord
 {
     public function __construct(
         public readonly int $x,
         public readonly int $y
     ) {
     }
-
 }

--- a/lib/bdf/src/BdfFont.php
+++ b/lib/bdf/src/BdfFont.php
@@ -18,10 +18,7 @@ final class BdfFont
 
     public function codePoint(int $codePoint): BdfGlyph
     {
-        if (!isset($this->glyphs[$codePoint])) {
-            throw new RuntimeException('No glyph for codepoint %d', $codePoint);
-        }
-        return $this->glyphs[$codePoint];
+        return $this->glyphs[$codePoint] ?? throw new RuntimeException('No glyph for codepoint %d', $codePoint);
     }
 
     /**

--- a/lib/bdf/src/BdfGlyph.php
+++ b/lib/bdf/src/BdfGlyph.php
@@ -8,13 +8,12 @@ final class BdfGlyph
      * @param array<int,int> $bitmap
      */
     public function __construct(
-        public array $bitmap,
-        public BdfBoundingBox $boundingBox,
-        public ?int $encoding,
-        public string $name,
-        public BdfCoord $deviceWidth,
-        public ?BdfCoord $scalableWidth
+        public readonly array $bitmap,
+        public readonly BdfBoundingBox $boundingBox,
+        public readonly ?int $encoding,
+        public readonly string $name,
+        public readonly BdfCoord $deviceWidth,
+        public readonly ?BdfCoord $scalableWidth
     ) {
     }
-
 }

--- a/lib/bdf/src/BdfMetadata.php
+++ b/lib/bdf/src/BdfMetadata.php
@@ -2,7 +2,7 @@
 
 namespace PhpTui\BDF;
 
-class BdfMetadata
+final class BdfMetadata
 {
     public function __construct(
         public readonly ?float $version,
@@ -12,5 +12,4 @@ class BdfMetadata
         public readonly ?BdfBoundingBox $boundingBox
     ) {
     }
-
 }

--- a/lib/bdf/src/BdfParser.php
+++ b/lib/bdf/src/BdfParser.php
@@ -25,7 +25,6 @@ final class BdfParser
     {
         $version = null;
         $name = null;
-        $size = null;
         $pointSize = null;
         $size = null;
         $boundingBox = null;
@@ -137,12 +136,11 @@ final class BdfParser
         if (is_numeric($value)) {
             return (int)$value;
         }
-        if (substr($value, 0, 1) === '"' && substr($value, -1) === '"') {
+        if (str_starts_with($value, '"') && str_ends_with($value, '"')) {
             return substr($value, 1, -1);
         }
 
         return $value;
-
     }
 
     /**

--- a/lib/bdf/src/BdfProperties.php
+++ b/lib/bdf/src/BdfProperties.php
@@ -13,10 +13,6 @@ final class BdfProperties
 
     public function get(BdfProperty $property): null|int|string
     {
-        if (isset($this->properties[$property->name])) {
-            return $this->properties[$property->name];
-        }
-
-        return null;
+        return $this->properties[$property->name] ?? null;
     }
 }

--- a/lib/bdf/src/BdfResult.php
+++ b/lib/bdf/src/BdfResult.php
@@ -11,9 +11,9 @@ final class BdfResult
      * @param TValue $value
      */
     private function __construct(
-        public bool $ok,
-        public mixed $value,
-        public BdfTokenStream $rest
+        public readonly bool $ok,
+        public readonly mixed $value,
+        public readonly BdfTokenStream $rest
     ) {
     }
 

--- a/lib/bdf/src/BdfSize.php
+++ b/lib/bdf/src/BdfSize.php
@@ -2,10 +2,11 @@
 
 namespace PhpTui\BDF;
 
-class BdfSize
+final class BdfSize
 {
-    public function __construct(public readonly int $width, public readonly int $height)
-    {
+    public function __construct(
+        public readonly int $width,
+        public readonly int $height
+    ) {
     }
-
 }

--- a/lib/bdf/src/BdfToken.php
+++ b/lib/bdf/src/BdfToken.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PhpTui\BDF;
+
+enum BdfToken
+{
+    case ENDCHAR;
+    case SIZE;
+    case STARTFONT;
+    case FONT;
+    case FONTBOUNDINGBOX;
+    case STARTPROPERTIES;
+    case ENDPROPERTIES;
+    case COMMENT;
+    case CHARS;
+    case STARTCHAR;
+    case ENCODING;
+    case SWIDTH;
+    case DWIDTH;
+    case BBX;
+    case BITMAP;
+    case ENDFONT;
+}

--- a/lib/bdf/src/BdfTokenStream.php
+++ b/lib/bdf/src/BdfTokenStream.php
@@ -33,9 +33,14 @@ final class BdfTokenStream
         return implode('', $this->tokens);
     }
 
-    public function is(string $string): bool
+    public function is(BdfToken $token): bool
     {
-        return $this->current() === $string;
+        return $this->current() === $token->name;
+    }
+
+    public function isNot(BdfToken $token): bool
+    {
+        return !$this->is($token);
     }
 
     public function current(): ?string


### PR DESCRIPTION
Nothing functional was changed. Implemented a new `BbfToken` enum and some code style adjustments.

```
1: <current> 2: main

Table
=====

<current>
+----------------+-----------------------+---------+----------+----------+----------+--------+-----------+
| benchmark      | subject               | memory  | min      | max      | mode     | rstdev | stdev     |
+----------------+-----------------------+---------+----------+----------+----------+--------+-----------+
| BdfParserBench | benchParseRealFont () | 6.033mb | 34.392ms | 35.264ms | 35.068ms | ±0.74% | 257.745μs |
+----------------+-----------------------+---------+----------+----------+----------+--------+-----------+

main
+----------------+-----------------------+---------+----------+----------+----------+--------+-----------+
| benchmark      | subject               | memory  | min      | max      | mode     | rstdev | stdev     |
+----------------+-----------------------+---------+----------+----------+----------+--------+-----------+
| BdfParserBench | benchParseRealFont () | 6.031mb | 34.525ms | 35.503ms | 34.739ms | ±0.81% | 281.788μs |
+----------------+-----------------------+---------+----------+----------+----------+--------+-----------+
```