### PR TITLE
Chore: add more strict rules to PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,11 @@
         "symfony/var-dumper": "^6.3",
         "roave/better-reflection": "^6.15",
         "phpstan/phpdoc-parser": "^1.24",
-        "phpbench/phpbench": "^1.2"
+        "phpbench/phpbench": "^1.2",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan-deprecation-rules": "^1.1",
+        "phpstan/phpstan-strict-rules": "^1.5",
+        "phpstan/phpstan-phpunit": "^1.0"
     },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan --memory-limit=1G",
@@ -50,5 +54,10 @@
             "@phpbench",
             "@docs"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/example/demo/src/App.php
+++ b/example/demo/src/App.php
@@ -64,7 +64,7 @@ final class App
 
     public static function new(?Terminal $terminal = null, ?Display $display = null): self
     {
-        $terminal = $terminal ?: Terminal::new();
+        $terminal = $terminal ?? Terminal::new();
         $pages = [];
 
         // build up an exhaustive set of pages
@@ -85,7 +85,7 @@ final class App
 
         return new self(
             $terminal,
-            $display ?: Display::fullscreen(PhpTermBackend::new($terminal)),
+            $display ?? Display::fullscreen(PhpTermBackend::new($terminal)),
             ActivePage::Events,
             $pages,
             [],

--- a/lib/docgen/src/Docgen.php
+++ b/lib/docgen/src/Docgen.php
@@ -91,7 +91,7 @@ final class Docgen
                         );
                     }
                     return new WidgetParam(
-                        type: $type ?: $phpType,
+                        type: $type ?? $phpType,
                         name: $prop->getName(),
                         description: $this->description($phpDoc),
                     );
@@ -129,7 +129,7 @@ final class Docgen
                         );
                     }
                     return new WidgetParam(
-                        type: $type ?: $phpType,
+                        type: $type ?? $phpType,
                         name: $prop->getName(),
                         description: $this->description($phpDoc),
                     );

--- a/lib/term/src/EventParser.php
+++ b/lib/term/src/EventParser.php
@@ -238,7 +238,7 @@ final class EventParser
     {
         $str = implode('', array_slice($buffer, 2, (int)array_key_last($buffer)));
         // split string into bytes
-        $parts = (array)explode(';', $str);
+        $parts = explode(';', $str);
 
         [$modifiers, $kind] = (function () use ($parts) {
             $modifierAndKindCode  = $this->modifierAndKindParsed($parts);

--- a/lib/term/src/InformationProvider/SizeFromSttyProvider.php
+++ b/lib/term/src/InformationProvider/SizeFromSttyProvider.php
@@ -16,7 +16,7 @@ final class SizeFromSttyProvider implements InformationProvider
 
     public static function new(?ProcessRunner $processRunner = null): self
     {
-        return new self($processRunner ?: new ProcRunner());
+        return new self($processRunner ?? new ProcRunner());
     }
 
     public function for(string $classFqn): ?TerminalInformation

--- a/lib/term/src/Painter/StringPainter.php
+++ b/lib/term/src/Painter/StringPainter.php
@@ -32,7 +32,7 @@ class StringPainter implements Painter
 
     public function toString(): string
     {
-        if (empty($this->grid)) {
+        if ($this->grid === []) {
             return '';
         }
         $maxX = max(

--- a/lib/term/src/ProcessRunner/ProcRunner.php
+++ b/lib/term/src/ProcessRunner/ProcRunner.php
@@ -20,11 +20,19 @@ final class ProcRunner implements ProcessRunner
         }
 
         $stdout = stream_get_contents($pipes[1]);
+        if ($stdout === false) {
+            throw new RuntimeException('Could not read from stdout stream');
+        }
+
         $stderr = stream_get_contents($pipes[2]);
+        if ($stderr === false) {
+            throw new RuntimeException('Could not read from stderr stream');
+        }
+
         fclose($pipes[1]);
         fclose($pipes[2]);
         $exitCode = proc_close($process);
 
-        return new ProcessResult($exitCode, $stdout ?: '', $stderr ?: '');
+        return new ProcessResult($exitCode, $stdout, $stderr);
     }
 }

--- a/lib/term/src/RawMode/SttyRawMode.php
+++ b/lib/term/src/RawMode/SttyRawMode.php
@@ -17,7 +17,7 @@ class SttyRawMode implements RawMode
 
     public static function new(?ProcessRunner $processRunner = null): self
     {
-        return new self($processRunner ?: new ProcRunner());
+        return new self($processRunner ?? new ProcRunner());
     }
 
     public function enable(): void

--- a/lib/term/src/Terminal.php
+++ b/lib/term/src/Terminal.php
@@ -36,13 +36,13 @@ class Terminal
         RawMode $rawMode = null,
     ): self {
         return new self(
-            $painter ?: AnsiPainter::new(StreamWriter::stdout()),
-            $infoProvider ?: AggregateInformationProvider::new([
+            $painter ?? AnsiPainter::new(StreamWriter::stdout()),
+            $infoProvider ?? AggregateInformationProvider::new([
                 SizeFromEnvVarProvider::new(),
                 SizeFromSttyProvider::new()
             ]),
-            $rawMode ?: SttyRawMode::new(),
-            $eventProvider ?: SyncEventProvider::new(),
+            $rawMode ?? SttyRawMode::new(),
+            $eventProvider ?? SyncEventProvider::new(),
         );
     }
 

--- a/lib/term/tests/TerminalTest.php
+++ b/lib/term/tests/TerminalTest.php
@@ -40,7 +40,7 @@ final class TerminalTest extends TestCase
             ->flush();
 
         self::assertCount(20, $dummy->actions());
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'AlternateScreenEnable(false)',
                 'AlternateScreenEnable(true)',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
         - lib
         - src
         - tests
+    strictRules:
+        booleansInConditions: false

--- a/src/Adapter/PhpTerm/PhpTermBackend.php
+++ b/src/Adapter/PhpTerm/PhpTermBackend.php
@@ -31,7 +31,7 @@ class PhpTermBackend implements Backend
 
     public static function new(?PhpTermTerminal $terminal = null): self
     {
-        return new self($terminal ?: PhpTermTerminal::new());
+        return new self($terminal ?? PhpTermTerminal::new());
     }
 
 

--- a/src/Model/Buffer.php
+++ b/src/Model/Buffer.php
@@ -118,7 +118,7 @@ final class Buffer implements Countable
 
     public function putString(Position $position, string $line, ?Style $style = null, int $width = PHP_INT_MAX): Position
     {
-        $style = $style ?: Style::default();
+        $style = $style ?? Style::default();
         try {
             $index = $position->toIndex($this->area);
         } catch (OutOfBoundsException $e) {

--- a/src/Model/Canvas/AggregateShapePainter.php
+++ b/src/Model/Canvas/AggregateShapePainter.php
@@ -19,8 +19,8 @@ class AggregateShapePainter implements ShapePainter
 
     public function draw(ShapePainter $shapePainter, Painter $painter, Shape $shape): void
     {
-        foreach ($this->painters as $shapePainter) {
-            $shapePainter->draw($this, $painter, $shape);
+        foreach ($this->painters as $aggregateShapePainter) {
+            $aggregateShapePainter->draw($this, $painter, $shape);
         }
     }
 

--- a/src/Model/Canvas/Grid/HalfBlockGrid.php
+++ b/src/Model/Canvas/Grid/HalfBlockGrid.php
@@ -71,6 +71,7 @@ class HalfBlockGrid extends CanvasGrid
             if ($upper !== AnsiColor::Reset && $lower === AnsiColor::Reset) {
                 return BlockSet::UPPER_HALF;
             }
+            /** @phpstan-ignore-next-line */
             if ($upper === AnsiColor::Reset && $lower !== AnsiColor::Reset) {
                 return BlockSet::LOWER_HALF;
             }
@@ -89,6 +90,7 @@ class HalfBlockGrid extends CanvasGrid
                 return new FgBgColor($upper, AnsiColor::Reset);
             }
             // lower half has been set: set the foreground color
+            /** @phpstan-ignore-next-line */
             if ($upper === AnsiColor::Reset && $lower !== AnsiColor::Reset) {
                 return new FgBgColor($lower, AnsiColor::Reset);
             }

--- a/src/Model/RgbColor.php
+++ b/src/Model/RgbColor.php
@@ -67,7 +67,7 @@ class RgbColor implements Color
         } // php modulus does not work with float
         $dX = $dC*(1-abs($dT-1));     // as used in the Wikipedia link
 
-        switch(floor($dH)) {
+        switch((int) floor($dH)) {
             case 0:
                 $dR = $dC;
                 $dG = $dX;

--- a/src/Model/Style.php
+++ b/src/Model/Style.php
@@ -46,9 +46,9 @@ final class Style implements Stringable
 
     public function patch(Style $other): self
     {
-        $this->fg = $other->fg ?: $this->fg;
-        $this->bg = $other->bg ?: $this->bg;
-        $this->underline = $other->underline ?: $this->underline;
+        $this->fg = $other->fg ?? $this->fg;
+        $this->bg = $other->bg ?? $this->bg;
+        $this->underline = $other->underline ?? $this->underline;
 
         $this->addModifiers->remove($other->subModifiers);
         $this->addModifiers->insert($other->addModifiers);

--- a/src/Model/Widget/FloatPosition.php
+++ b/src/Model/Widget/FloatPosition.php
@@ -41,6 +41,7 @@ final class FloatPosition implements Stringable
     public function change(Closure $closure): void
     {
         $new = $closure($this->x, $this->y);
+        /** @phpstan-ignore-next-line runtime check */
         if (!is_array($new)) {
             throw new RuntimeException(sprintf('Change closure must return an array, got: %s', gettype($new)));
         }

--- a/src/Model/WidgetRenderer/AggregateWidgetRenderer.php
+++ b/src/Model/WidgetRenderer/AggregateWidgetRenderer.php
@@ -26,8 +26,8 @@ class AggregateWidgetRenderer implements WidgetRenderer
 
     public function render(WidgetRenderer $renderer, Widget $widget, Area $area, Buffer $buffer): void
     {
-        foreach ($this->renderers as $renderer) {
-            $renderer->render($this, $widget, $area, $buffer);
+        foreach ($this->renderers as $aggregateRenderer) {
+            $aggregateRenderer->render($this, $widget, $area, $buffer);
         }
     }
 

--- a/src/Widget/BlockRenderer.php
+++ b/src/Widget/BlockRenderer.php
@@ -214,7 +214,7 @@ final class BlockRenderer implements WidgetRenderer
         return [
             $leftBorderDx ? 1 : 0,
             $rightBorderDx ? 1 : 0,
-            $area->width - max(0, $leftBorderDx, $rightBorderDx),
+            $area->width - ($leftBorderDx || $rightBorderDx ? 1 : 0),
         ];
     }
 

--- a/src/Widget/ChartRenderer.php
+++ b/src/Widget/ChartRenderer.php
@@ -126,7 +126,7 @@ final class ChartRenderer implements WidgetRenderer
             $first = $chart->xAxis->labels[array_key_first($chart->xAxis->labels)];
             $firstLabelWidth = $first->width();
             $widthOfYAxis = match ($chart->xAxis->labelAlignment) {
-                HorizontalAlignment::Left => $firstLabelWidth - $hasYAxis ? 1 : 0,
+                HorizontalAlignment::Left => $firstLabelWidth - (int) $hasYAxis,
                 HorizontalAlignment::Center => $firstLabelWidth / 2,
                 HorizontalAlignment::Right => 0,
             };

--- a/src/Widget/ChartRenderer.php
+++ b/src/Widget/ChartRenderer.php
@@ -63,12 +63,12 @@ final class ChartRenderer implements WidgetRenderer
 
         foreach ($widget->dataSets as $dataSet) {
             $renderer->render($renderer, Canvas::default()
-                ->backgroundColor($widget->style->bg ?: AnsiColor::Reset)
+                ->backgroundColor($widget->style->bg ?? AnsiColor::Reset)
                 ->xBounds($widget->xAxis->bounds)
                 ->yBounds($widget->yAxis->bounds)
                 ->marker($dataSet->marker)
                 ->paint(function (CanvasContext $context) use ($dataSet): void {
-                    $context->draw(Points::new($dataSet->data, $dataSet->style->fg ?: AnsiColor::Reset));
+                    $context->draw(Points::new($dataSet->data, $dataSet->style->fg ?? AnsiColor::Reset));
                 }), $layout->graphArea, $buffer);
 
         }
@@ -141,7 +141,7 @@ final class ChartRenderer implements WidgetRenderer
         if (null === $layout->labelX) {
             return;
         }
-        $labels = $chart->xAxis->labels ?: [];
+        $labels = $chart->xAxis->labels ?? [];
         if (count($labels) < 2) {
             return;
         }

--- a/src/Widget/ItemListRenderer.php
+++ b/src/Widget/ItemListRenderer.php
@@ -31,7 +31,7 @@ class ItemListRenderer implements WidgetRenderer
         $listHeight = $listArea->height;
         [$start, $end] = $this->getItemsBounds($widget, $listHeight);
         $widget->state->offset = $start;
-        $highlightSymbol = $widget->highlightSymbol ?? '';
+        $highlightSymbol = $widget->highlightSymbol;
         $blankSymbol = str_repeat(' ', mb_strlen($highlightSymbol));
         $currentHeight = 0;
         $selectionSpacing = $widget->highlightSpacing->shouldAdd($widget->state->selected !== null);

--- a/src/Widget/ParagraphRenderer.php
+++ b/src/Widget/ParagraphRenderer.php
@@ -38,7 +38,7 @@ class ParagraphRenderer implements WidgetRenderer
                 }
                 return $ac;
             }, []);
-            return [ $graphemes, $line->alignment ?: $widget->alignment ];
+            return [ $graphemes, $line->alignment ?? $widget->alignment ];
         }, $widget->text->lines);
 
         $lineComposer = $this->createLineComposer(

--- a/src/Widget/TableRenderer.php
+++ b/src/Widget/TableRenderer.php
@@ -74,13 +74,13 @@ final class TableRenderer implements WidgetRenderer
 
         [$start, $end] = self::getRowBounds($widget, $rowsHeight);
         $widget->state->offset = $start;
-        foreach (array_slice($widget->rows, $start, $end - $start) as $i => $tableRow) {
+        foreach (array_slice($widget->rows, $start, $end - $start) as $rowIndex => $tableRow) {
             [$rowY, $innerOffset] = [$tableArea->top() + $currentHeight, $tableArea->left()];
 
             $currentHeight += $tableRow->totalHeight();
             $tableRowArea = Area::fromScalars($innerOffset, $rowY, $tableArea->width, $tableRow->height);
             $buffer->setStyle($tableRowArea, $tableRow->style);
-            $isSelected = $widget->state->selected === $i + $start;
+            $isSelected = $widget->state->selected === $rowIndex + $start;
             if ($selectionWidth > 0 && $isSelected) {
                 $buffer->putString(
                     Position::at(
@@ -92,8 +92,8 @@ final class TableRenderer implements WidgetRenderer
                     $tableArea->width,
                 );
             }
-            foreach ($columnWidths as $i => $width) {
-                $cell = $tableRow->getCell($i);
+            foreach ($columnWidths as $cellIndex => $width) {
+                $cell = $tableRow->getCell($cellIndex);
                 if (null === $cell) {
                     continue;
                 }

--- a/src/Widget/TableRenderer.php
+++ b/src/Widget/TableRenderer.php
@@ -32,7 +32,7 @@ final class TableRenderer implements WidgetRenderer
         ) ? mb_strlen($widget->highlightSymbol) : 0;
 
         $columnWidths = $this->getColumnsWidths($widget, $tableArea->width, intval($selectionWidth));
-        $highlightSymbol = $widget->highlightSymbol ?: '';
+        $highlightSymbol = $widget->highlightSymbol;
         $currentHeight = 0;
         $rowsHeight = $tableArea->height;
 

--- a/tests/Example/DemoTest.php
+++ b/tests/Example/DemoTest.php
@@ -122,7 +122,7 @@ class DemoTest extends TestCase
 
     private function assertSnapshot(string $name, DummyBackend $backend): void
     {
-        $name = substr($name, strrpos($name, ':') + 5);
+        $name = substr($name, (int) strrpos($name, ':') + 5);
         $filename = sprintf('%s/snapshot/%s.snapshot', __DIR__, $name);
         if (!file_exists($filename) || getenv('SNAPSHOT_APPROVE')) {
             file_put_contents($filename, $backend->flushed());

--- a/tests/Model/DisplayTest.php
+++ b/tests/Model/DisplayTest.php
@@ -14,12 +14,6 @@ use PhpTui\Tui\Shape\Points;
 
 class DisplayTest extends TestCase
 {
-    public function testCreatesFullscreenTerminal(): void
-    {
-        $terminal = Display::fullscreen(DummyBackend::fromDimensions(10, 10));
-        self::assertInstanceOf(Display::class, $terminal);
-    }
-
     public function testAutoresize(): void
     {
         $backend = DummyBackend::fromDimensions(4, 4);
@@ -99,5 +93,4 @@ class DisplayTest extends TestCase
             $backend->toString()
         );
     }
-
 }


### PR DESCRIPTION
This PR introduces three new PHPStan extensions to the project:

- phpstan/phpstan-deprecation-rules
- phpstan/phpstan-strict-rules
- phpstan/phpstan-phpunit

I believe that the `phpstan-strict-rule` is an excellent addition, helping us avoid simple errors.

The rule `booleansInConditions` is currently disabled due to 44 warnings that need to be addressed. For instance:

```php
$op1 = '';
$op2 = true;

// Will throw a warning
if ($op1 && $op2) ...
```

If you think is Ok, I can enable this rule and make the necessary modifications in another PR.

@dantleech, I completely understand if you prefer not to change these parts. I'm aware that PRs affecting numerous files can be overwhelming to review. So, you can feel totally free to close this PR. :blush: 

Failing tests aren´t related. :sweat_smile: