### PR TITLE
Perf: precompute width and height calculations

### DIFF
--- a/src/Model/Canvas/Painter.php
+++ b/src/Model/Canvas/Painter.php
@@ -8,8 +8,14 @@ use PhpTui\Tui\Model\Widget\FloatPosition;
 
 class Painter
 {
+    private float $widthFactor;
+
+    private float $heightFactor;
+
     public function __construct(public CanvasContext $context, public Resolution $resolution)
     {
+        $this->widthFactor = ($this->resolution->width - 1.0) / $this->context->xBounds->length();
+        $this->heightFactor = ($this->resolution->height - 1.0) / $this->context->yBounds->length();
     }
 
     /**
@@ -31,20 +37,15 @@ class Painter
         if ($floatPosition->outOfBounds($this->context->xBounds, $this->context->yBounds)) {
             return null;
         }
-        $width = $this->context->xBounds->length();
-        $height = $this->context->yBounds->length();
-        if ($width === 0.0 || $height === 0.0) {
-            return null;
-        }
-        $x = ($floatPosition->x - $this->context->xBounds->min) * ($this->resolution->width - 1.0) / $width;
-        $y = ($this->context->yBounds->max - $floatPosition->y) * ($this->resolution->height - 1.0) / $height;
 
-        return Position::at(intval($x), intval($y));
+        $x = ($floatPosition->x - $this->context->xBounds->min) * $this->widthFactor;
+        $y = ($this->context->yBounds->max - $floatPosition->y) * $this->heightFactor;
+
+        return Position::at((int) $x, (int) $y);
     }
 
     public function paint(Position $position, Color $color): void
     {
         $this->context->grid->paint($position, $color);
     }
-
 }

--- a/src/Model/Canvas/Painter.php
+++ b/src/Model/Canvas/Painter.php
@@ -12,10 +12,18 @@ class Painter
 
     private float $heightFactor;
 
+    private bool $hasValidDimensions;
+
     public function __construct(public CanvasContext $context, public Resolution $resolution)
     {
-        $this->widthFactor = ($this->resolution->width - 1.0) / $this->context->xBounds->length();
-        $this->heightFactor = ($this->resolution->height - 1.0) / $this->context->yBounds->length();
+        $width = $this->context->xBounds->length();
+        $height = $this->context->yBounds->length();
+        $this->hasValidDimensions = $width > 0 && $height > 0;
+
+        if ($this->hasValidDimensions) {
+            $this->widthFactor = ($this->resolution->width - 1.0) / $width;
+            $this->heightFactor = ($this->resolution->height - 1.0) / $height;
+        }
     }
 
     /**
@@ -34,7 +42,7 @@ class Painter
      */
     public function getPoint(FloatPosition $floatPosition): ?Position
     {
-        if ($floatPosition->outOfBounds($this->context->xBounds, $this->context->yBounds)) {
+        if (!$this->hasValidDimensions || $floatPosition->outOfBounds($this->context->xBounds, $this->context->yBounds)) {
             return null;
         }
 


### PR DESCRIPTION
With this change, factors for width and height calculations are precomputed in the constructor. This prevents their recalculation every time getPoint is called.

In the `ImagePainter`, where `getPoint()` is executed tens of thousands of times, this can make a significant difference.

Benchmark Results for `ImageShapeBench`:

```
+-----------+---------------------+--------+------------+--------+------------+------+-----------+----------+
| suite     | date                | php    | vcs branch | xdebug | iterations | revs | mode      | net_time |
+-----------+---------------------+--------+------------+--------+------------+------+-----------+----------+
| <current> | 2023-11-11 18:56:52 | 8.2.12 | painter    | false  | 4          | 100  | 109.289ms | 10.898s  |
| main      | 2023-11-11 18:50:03 | 8.2.12 | main       | false  | 4          | 100  | 120.271ms | 12.091s  |
+-----------+---------------------+--------+------------+--------+------------+------+-----------+----------+
```

```
<current>
+-----------------+--------------------+----------+-----------+-----------+-----------+--------+-----------+
| benchmark       | subject            | memory   | min       | max       | mode      | rstdev | stdev     |
+-----------------+--------------------+----------+-----------+-----------+-----------+--------+-----------+
| ImageShapeBench | benchImageShape () | 12.327mb | 108.381ms | 109.518ms | 109.289ms | ±0.44% | 480.182μs |
+-----------------+--------------------+----------+-----------+-----------+-----------+--------+-----------+

main
+-----------------+--------------------+----------+-----------+-----------+-----------+--------+---------+
| benchmark       | subject            | memory   | min       | max       | mode      | rstdev | stdev   |
+-----------------+--------------------+----------+-----------+-----------+-----------+--------+---------+
| ImageShapeBench | benchImageShape () | 12.327mb | 120.072ms | 122.903ms | 120.271ms | ±0.96% | 1.162ms |
+-----------------+--------------------+----------+-----------+-----------+-----------+--------+---------+
```

**Note:**  I have removed this check:

```php
if ($width === 0.0 || $height === 0.0) {
    return null;
}
```

I'm wondering if it has any real use case. Does it? If so, I can bring it back.