### PR TITLE
Chore: Make `Black` start at `0` in `AnsiColor`

### DIFF
--- a/example/demo/src/Page/ColorsPage.php
+++ b/example/demo/src/Page/ColorsPage.php
@@ -34,7 +34,7 @@ class ColorsPage implements Component
         $x = 0;
         $y = 0;
         for ($i = 0; $i < 15; $i++) {
-            $color = AnsiColor::fromIndex($i);
+            $color = AnsiColor::from($i);
             $name = $color->name;
             $buffer->putSpan(
                 Position::at($x, $y),

--- a/src/Model/AnsiColor.php
+++ b/src/Model/AnsiColor.php
@@ -2,46 +2,28 @@
 
 namespace PhpTui\Tui\Model;
 
-use RuntimeException;
-
-enum AnsiColor implements Color
+enum AnsiColor: int implements Color
 {
-    case Reset;
-    case Black;
-    case Red;
-    case Green;
-    case Yellow;
-    case Blue;
-    case Magenta;
-    case Cyan;
-    case Gray;
-    case DarkGray;
-    case LightRed;
-    case LightGreen;
-    case LightYellow;
-    case LightBlue;
-    case LightMagenta;
-    case LightCyan;
-    case White;
+    case Reset = -1;
+    case Black = 0;
+    case Red = 1;
+    case Green = 2;
+    case Yellow = 3;
+    case Blue = 4;
+    case Magenta = 5;
+    case Cyan = 6;
+    case Gray = 7;
+    case DarkGray = 8;
+    case LightRed = 9;
+    case LightGreen = 10;
+    case LightYellow = 11;
+    case LightBlue = 12;
+    case LightMagenta = 13;
+    case LightCyan = 14;
+    case White = 15;
 
     public function debugName(): string
     {
         return $this->name;
-    }
-
-    /**
-     * Return ANSI color from 0 based index (0 = black, 15 = white)
-     */
-    public static function fromIndex(int $index): self
-    {
-        $cases = self::cases();
-        if (!isset($cases[$index + 1])) {
-            throw new RuntimeException(sprintf(
-                'ANSI color with index "%d" does not exist, must be in range of 0-15',
-                $index
-            ));
-        }
-
-        return $cases[$index + 1];
     }
 }

--- a/tests/Model/AnsiColorTest.php
+++ b/tests/Model/AnsiColorTest.php
@@ -4,6 +4,7 @@ namespace PhpTui\Tui\Tests\Model;
 
 use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Model\AnsiColor;
+use ValueError;
 
 class AnsiColorTest extends TestCase
 {
@@ -15,7 +16,7 @@ class AnsiColorTest extends TestCase
 
     public function testFromIndexOutOfBounds(): void
     {
-        $this->expectExceptionMessage('16 is not a valid backing value for enum PhpTui\Tui\Model\AnsiColor');
+        $this->expectException(ValueError::class);
         self::assertEquals(AnsiColor::White, AnsiColor::from(16));
     }
 }

--- a/tests/Model/AnsiColorTest.php
+++ b/tests/Model/AnsiColorTest.php
@@ -9,13 +9,13 @@ class AnsiColorTest extends TestCase
 {
     public function testFromIndex(): void
     {
-        self::assertEquals(AnsiColor::Black, AnsiColor::fromIndex(0));
-        self::assertEquals(AnsiColor::White, AnsiColor::fromIndex(15));
+        self::assertEquals(AnsiColor::Black, AnsiColor::from(0));
+        self::assertEquals(AnsiColor::White, AnsiColor::from(15));
     }
 
     public function testFromIndexOutOfBounds(): void
     {
-        $this->expectExceptionMessage('ANSI color with index "16" does not exist, must be in range of 0-15');
-        self::assertEquals(AnsiColor::White, AnsiColor::fromIndex(16));
+        $this->expectExceptionMessage('16 is not a valid backing value for enum PhpTui\Tui\Model\AnsiColor');
+        self::assertEquals(AnsiColor::White, AnsiColor::from(16));
     }
 }


### PR DESCRIPTION
With these changes, we can get rid of the `fromIndex()` method. Wdyt?