### PR TITLE
Style: add `removeModifier()` and `underline()` methods

### DIFF
--- a/src/Model/Style.php
+++ b/src/Model/Style.php
@@ -44,6 +44,18 @@ final class Style implements Stringable
         return $this;
     }
 
+    public function bg(Color $color): self
+    {
+        $this->bg = $color;
+        return $this;
+    }
+
+    public function underline(Color $color): self
+    {
+        $this->underline = $color;
+        return $this;
+    }
+
     public function patch(Style $other): self
     {
         $this->fg = $other->fg ?? $this->fg;
@@ -52,19 +64,21 @@ final class Style implements Stringable
 
         $this->addModifiers->remove($other->subModifiers);
         $this->addModifiers->insert($other->addModifiers);
+        $this->subModifiers->remove($other->addModifiers);
+        $this->subModifiers->insert($other->subModifiers);
 
-        return $this;
-    }
-
-    public function bg(Color $color): self
-    {
-        $this->bg = $color;
         return $this;
     }
 
     public function addModifier(Modifier $modifier): self
     {
         $this->addModifiers->add($modifier);
+        return $this;
+    }
+
+    public function removeModifier(Modifier $modifier): self
+    {
+        $this->subModifiers->add($modifier);
         return $this;
     }
 }

--- a/tests/Model/StyleTest.php
+++ b/tests/Model/StyleTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace PhpTui\Tui\Tests\Model;
+
+use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Modifier;
+use PhpTui\Tui\Model\Modifiers;
+use PhpTui\Tui\Model\Style;
+use PHPUnit\Framework\TestCase;
+
+class StyleTest extends TestCase
+{
+    public function testDefault(): void
+    {
+        $style = Style::default();
+
+        self::assertNull($style->fg);
+        self::assertNull($style->bg);
+        self::assertNull($style->underline);
+        self::assertEquals(Modifiers::none()->toInt(), $style->addModifiers->toInt());
+        self::assertEquals(Modifiers::none()->toInt(), $style->subModifiers->toInt());
+    }
+
+    public function testFg(): void
+    {
+        $style = Style::default()->fg(AnsiColor::Red);
+
+        self::assertSame(AnsiColor::Red, $style->fg);
+    }
+
+    public function testBg(): void
+    {
+        $style = Style::default()->bg(AnsiColor::Blue);
+
+        self::assertSame(AnsiColor::Blue, $style->bg);
+    }
+
+    public function testAddModifier(): void
+    {
+        $style = Style::default()->addModifier(Modifier::Bold);
+
+        self::assertTrue($style->addModifiers->contains(Modifier::Bold));
+    }
+
+    public function testSubModifier(): void
+    {
+        $style = Style::default()->removeModifier(Modifier::Italic);
+
+        self::assertTrue($style->subModifiers->contains(Modifier::Italic));
+    }
+
+    public function testPatch(): void
+    {
+        $style1 = Style::default()->bg(AnsiColor::Red);
+        $style2 = Style::default()
+                    ->fg(AnsiColor::Blue)
+                    ->addModifier(Modifier::Bold)
+                    ->addModifier(Modifier::Underlined);
+
+        $combined = $style1->patch($style2);
+
+        self::assertEquals(
+            Modifiers::none()->toInt(),
+            $combined->subModifiers->toInt(),
+        );
+
+        self::assertEquals(
+            Modifiers::fromInt(Modifier::Bold->value | Modifier::Underlined->value)->toInt(),
+            $combined->addModifiers->toInt(),
+        );
+
+        self::assertSame(
+            (string) Style::default()->patch($style1)->patch($style2),
+            (string) $combined
+        );
+
+        self::assertSame(AnsiColor::Blue, $combined->fg);
+        self::assertSame(AnsiColor::Red, $combined->bg);
+
+        $combined2 = Style::default()->patch($combined)->patch(
+            Style::default()
+                ->removeModifier(Modifier::Bold)
+                ->addModifier(Modifier::Italic),
+        );
+
+        self::assertEquals(
+            Modifiers::fromModifier(Modifier::Bold)->toInt(),
+            $combined2->subModifiers->toInt(),
+        );
+
+        self::assertEquals(
+            Modifiers::fromInt(Modifier::Italic->value | Modifier::Underlined->value)->toInt(),
+            $combined2->addModifiers->toInt(),
+        );
+
+        self::assertSame(AnsiColor::Blue, $combined->fg);
+        self::assertSame(AnsiColor::Red, $combined->bg);
+    }
+
+    public function testToString(): void
+    {
+        $style = Style::default()
+                    ->bg(AnsiColor::Red)
+                    ->underline(AnsiColor::Blue)
+                    ->addModifier(Modifier::Bold)
+                    ->removeModifier(Modifier::Italic)
+                    ->removeModifier(Modifier::Underlined);
+
+        $expectedString = sprintf(
+            'Style(fg:%s,bg: %s,u:%s,+mod:%d,-mod:%d)',
+            '-',
+            AnsiColor::Red->debugName(),
+            AnsiColor::Blue->debugName(),
+            Modifiers::fromModifier(Modifier::Bold)->toInt(),
+            Modifiers::fromInt(Modifier::Italic->value | Modifier::Underlined->value)->toInt()
+        );
+
+        self::assertEquals($expectedString, (string) $style);
+    }
+}


### PR DESCRIPTION
Changes:

- Added `removeModifier()` and `underline()` methods.
- Support for `subModifiers` when patching.
- Added tests.