### PR TITLE
Chore: add some new rules to PHP-CS-FIXER

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,6 +16,7 @@ return (new Config())
         'no_unused_imports' => true,
         'phpdoc_to_property_type' => true,
         'declare_strict_types' => true,
+        'modernize_types_casting' => true,
         'no_superfluous_phpdoc_tags' => [
             'remove_inheritdoc' => true,
             'allow_mixed' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,6 +28,10 @@ return (new Config())
                 'trait_import' => 'only_if_meta',
             ],
         ],
+        'ordered_imports' => [
+            'imports_order' => ['class', 'function', 'const'],
+            'sort_algorithm' => 'alpha',
+        ],
         'no_empty_phpdoc' => true,
         'phpdoc_trim' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,7 +12,7 @@ $finder = Finder::create()
 return (new Config())
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PSR2' => true,
+        '@PSR12' => true,
         'no_unused_imports' => true,
         'phpdoc_to_property_type' => true,
         'no_superfluous_phpdoc_tags' => [
@@ -37,5 +37,6 @@ return (new Config())
         'global_namespace_import' => true,
         'no_trailing_whitespace' => true,
         'no_whitespace_in_blank_line' => true,
+        'blank_line_before_statement' => true,
     ])
     ->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,6 +15,7 @@ return (new Config())
         '@PSR12' => true,
         'no_unused_imports' => true,
         'phpdoc_to_property_type' => true,
+        'declare_strict_types' => true,
         'no_superfluous_phpdoc_tags' => [
             'remove_inheritdoc' => true,
             'allow_mixed' => true,

--- a/example/demo/src/ActivePage.php
+++ b/example/demo/src/ActivePage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo;
 
 enum ActivePage

--- a/example/demo/src/App.php
+++ b/example/demo/src/App.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo;
 
 use PhpTui\Term\Actions;
 use PhpTui\Term\ClearType;
 use PhpTui\Term\Event\CharKeyEvent;
 use PhpTui\Term\Terminal;
+use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend as PhpTuiPhpTermBackend;
 use PhpTui\Tui\DisplayBuilder;
 use PhpTui\Tui\Example\Demo\Page\BlocksPage;
 use PhpTui\Tui\Example\Demo\Page\CanvasPage;
@@ -18,8 +21,10 @@ use PhpTui\Tui\Example\Demo\Page\ItemListPage;
 use PhpTui\Tui\Example\Demo\Page\SpritePage;
 use PhpTui\Tui\Example\Demo\Page\TablePage;
 use PhpTui\Tui\Extension\Bdf\BdfExtension;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Grid;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 use PhpTui\Tui\Extension\ImageMagick\ImageMagickExtension;
-use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend as PhpTuiPhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Backend;
 use PhpTui\Tui\Model\Constraint;
@@ -33,9 +38,6 @@ use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Span;
 use PhpTui\Tui\Model\Widget\Text;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Grid;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 use Throwable;
 
 /**
@@ -92,6 +94,7 @@ final class App
             ->addExtension(new ImageMagickExtension())
             ->addExtension(new BdfExtension())
             ->build();
+
         return new self(
             $terminal,
             $display,
@@ -107,10 +110,12 @@ final class App
             // enable "raw" mode to remove default terminal behavior (e.g.
             // echoing key presses)
             $this->terminal->enableRawMode();
+
             return $this->doRun();
         } catch (Throwable $err) {
             $this->terminal->disableRawMode();
             $this->terminal->queue(Actions::clear(ClearType::All));
+
             throw $err;
         }
     }
@@ -260,6 +265,7 @@ final class App
                 $ac[$timestamp] = 0;
             }
             $ac[$timestamp]++;
+
             return $ac;
         }, []);
 

--- a/example/demo/src/Component.php
+++ b/example/demo/src/Component.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo;
 
 use PhpTui\Term\Event;

--- a/example/demo/src/Page/BlocksPage.php
+++ b/example/demo/src/Page/BlocksPage.php
@@ -1,28 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Tui\Example\Demo\Component;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
+use PhpTui\Tui\Extension\Core\Widget\Grid;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Modifier;
-use PhpTui\Tui\Model\Widget\BorderType;
+use PhpTui\Tui\Model\Style;
+use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\BorderType;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Span;
+use PhpTui\Tui\Model\Widget\Text;
 use PhpTui\Tui\Model\Widget\Title;
 use PhpTui\Tui\Model\Widget\VerticalAlignment;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Model\Style;
-use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
-use PhpTui\Tui\Extension\Core\Widget\Grid;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap;
-use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\Widget\Text;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 
 class BlocksPage implements Component
 {
@@ -76,6 +78,7 @@ class BlocksPage implements Component
     public function lorem(): Paragraph
     {
         $text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+
         return Paragraph::fromText(
             Text::styled(
                 $text,

--- a/example/demo/src/Page/CanvasPage.php
+++ b/example/demo/src/Page/CanvasPage.php
@@ -1,23 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Term\Event\CharKeyEvent;
 use PhpTui\Tui\Example\Demo\Component;
+use PhpTui\Tui\Extension\Core\Shape\Map;
+use PhpTui\Tui\Extension\Core\Shape\MapResolution;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Canvas as PhpTuiCanvas;
 use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Modifier;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
+use PhpTui\Tui\Model\Widget\Borders;
 use PhpTui\Tui\Model\Widget\Line as PhpTuiLine;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Canvas as PhpTuiCanvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Model\Widget\Borders;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Shape\MapResolution;
-use PhpTui\Tui\Extension\Core\Shape\Map;
 
 class CanvasPage implements Component
 {

--- a/example/demo/src/Page/CanvasScalingPage.php
+++ b/example/demo/src/Page/CanvasScalingPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
@@ -9,26 +11,26 @@ use PhpTui\Term\Size;
 use PhpTui\Term\Terminal;
 use PhpTui\Tui\Example\Demo\Component;
 use PhpTui\Tui\Extension\Bdf\Shape\TextShape;
+use PhpTui\Tui\Extension\Core\Shape\Circle;
+use PhpTui\Tui\Extension\Core\Shape\ClosureShape;
+use PhpTui\Tui\Extension\Core\Shape\Line;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Extension\Core\Widget\Grid;
 use PhpTui\Tui\Extension\ImageMagick\Shape\ImageShape;
 use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Canvas\Painter;
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\Painter;
-use PhpTui\Tui\Model\Canvas\Shape;
-use PhpTui\Tui\Extension\Core\Shape\Circle;
-use PhpTui\Tui\Extension\Core\Shape\ClosureShape;
-use PhpTui\Tui\Extension\Core\Shape\Line;
-use PhpTui\Tui\Extension\Core\Widget\Grid;
 
 class CanvasScalingPage implements Component
 {
-    const DELTA = 5;
+    public const DELTA = 5;
 
     private TextShape $text;
 
@@ -107,16 +109,16 @@ class CanvasScalingPage implements Component
     {
         if ($event instanceof CodedKeyEvent) {
             if ($event->code === KeyCode::Right) {
-                $this->xMax+=self::DELTA;
+                $this->xMax += self::DELTA;
             }
             if ($event->code === KeyCode::Left) {
-                $this->xMax-=self::DELTA;
+                $this->xMax -= self::DELTA;
             }
             if ($event->code === KeyCode::Up) {
-                $this->yMax+=self::DELTA;
+                $this->yMax += self::DELTA;
             }
             if ($event->code === KeyCode::Down) {
-                $this->yMax-=self::DELTA;
+                $this->yMax -= self::DELTA;
             }
             if ($event->code === KeyCode::Tab) {
                 $this->marker++;

--- a/example/demo/src/Page/ChartPage.php
+++ b/example/demo/src/Page/ChartPage.php
@@ -1,22 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Tui\Example\Demo\Component;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Chart;
+use PhpTui\Tui\Extension\Core\Widget\Chart\Axis;
+use PhpTui\Tui\Extension\Core\Widget\Chart\DataSet;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Style;
+use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\Borders;
 use PhpTui\Tui\Model\Widget\Line;
-use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Chart;
-use PhpTui\Tui\Extension\Core\Widget\Chart\Axis;
-use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Extension\Core\Widget\Chart\DataSet;
 use PhpTui\Tui\Model\Widget\Span;
+use PhpTui\Tui\Model\Widget\Title;
 
 class ChartPage implements Component
 {
@@ -78,11 +80,12 @@ class ChartPage implements Component
     {
         $data = [];
         for ($i = 0; $i < 400; $i++) {
-            $point = intval(sin(
+            $point = (int) (sin(
                 ($this->tick + $i + $offset) % 360 / 10
             ) * 400);
             $data[] = [$i, $point];
         }
+
         return $data;
     }
 }

--- a/example/demo/src/Page/ColorsPage.php
+++ b/example/demo/src/Page/ColorsPage.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Tui\Example\Demo\Component;
+use PhpTui\Tui\Extension\Core\Widget\RawWidget;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Position;
@@ -11,7 +14,6 @@ use PhpTui\Tui\Model\RgbColor;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\Span;
-use PhpTui\Tui\Extension\Core\Widget\RawWidget;
 
 class ColorsPage implements Component
 {
@@ -19,6 +21,7 @@ class ColorsPage implements Component
     public function build(): Widget
     {
         $this->ticker++;
+
         return RawWidget::new(function (Buffer $buffer): void {
             $this->write16Colors($buffer);
             $this->writeRgbColors($buffer);
@@ -51,7 +54,7 @@ class ColorsPage implements Component
         $y = 3;
         $tick = $this->ticker;
         $saturation = (50 + $tick) % 100;
-        $lightness = (50 + intval($tick / 3))  % 100;
+        $lightness = (50 + (int) ($tick / 3))  % 100;
         $buffer->putString(Position::at(0, 2), sprintf('Saturation: %d, Lightness: %d', $saturation, $lightness));
         for ($i = 0; $i < 360; $i++) {
             $color = RgbColor::fromHsv($i, $saturation, $lightness);

--- a/example/demo/src/Page/EventsPage.php
+++ b/example/demo/src/Page/EventsPage.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Tui\Example\Demo\Component;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\ItemList;
+use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\Borders;
 use PhpTui\Tui\Model\Widget\Text;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\ItemList;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
 
 final class EventsPage implements Component
 {

--- a/example/demo/src/Page/ImagePage.php
+++ b/example/demo/src/Page/ImagePage.php
@@ -1,21 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Tui\Example\Demo\Component;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Extension\Core\Widget\Grid;
 use PhpTui\Tui\Extension\ImageMagick\Shape\ImageShape;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\Widget\BorderType;
 use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\BorderType;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Widget\Grid;
 
 final class ImagePage implements Component
 {
@@ -29,6 +31,7 @@ final class ImagePage implements Component
         if (!isset($this->images)) {
             $this->images = array_map(function (string $name) {
                 $shape = ImageShape::fromPath(__DIR__ . '/../../assets/' . $name);
+
                 return Block::default()
                     ->titles(Title::fromString(sprintf('Image: %s', $name)))
                     ->borders(Borders::ALL)

--- a/example/demo/src/Page/ItemListPage.php
+++ b/example/demo/src/Page/ItemListPage.php
@@ -1,24 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Tui\Example\Demo\Component;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\ItemList;
+use PhpTui\Tui\Extension\Core\Widget\ItemList\ItemListState;
+use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\Borders;
-use PhpTui\Tui\Model\Widget\Span;
 use PhpTui\Tui\Model\Widget\Line;
+use PhpTui\Tui\Model\Widget\Span;
 use PhpTui\Tui\Model\Widget\Text;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\ItemListState;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
-use PhpTui\Tui\Extension\Core\Widget\ItemList;
 
 final class ItemListPage implements Component
 {
-    const EVENTS = [
+    public const EVENTS = [
         ['Event1', 'INFO'],
         ['Event2', 'INFO'],
         ['Event3', 'CRITICAL'],

--- a/example/demo/src/Page/SpritePage.php
+++ b/example/demo/src/Page/SpritePage.php
@@ -1,30 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Tui\Example\Demo\Component;
 use PhpTui\Tui\Extension\Bdf\Shape\TextShape;
+use PhpTui\Tui\Extension\Core\Shape\Points;
+use PhpTui\Tui\Extension\Core\Shape\Sprite;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Extension\Core\Widget\Grid;
 use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\RgbColor;
 use PhpTui\Tui\Model\Style;
-use PhpTui\Tui\Model\Widget\BorderType;
-use PhpTui\Tui\Model\Widget\Borders;
-use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Shape\Points;
-use PhpTui\Tui\Extension\Core\Shape\Sprite;
-use PhpTui\Tui\Extension\Core\Widget\Grid;
+use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\BorderType;
+use PhpTui\Tui\Model\Widget\FloatPosition;
 
 class SpritePage implements Component
 {
-    const WIDTH = 100;
-    const HEIGHT = 30;
+    public const WIDTH = 100;
+    public const HEIGHT = 30;
 
     private Sprite $elephant;
 
@@ -190,6 +192,7 @@ class SpritePage implements Component
         foreach ($this->stars as $i => [$x, $y]) {
             if ($x > self::WIDTH) {
                 $this->stars[$i] = [0, $y];
+
                 continue;
             }
             $this->stars[$i] = [$x + 1, $y];
@@ -203,7 +206,8 @@ class SpritePage implements Component
                 if ($x < 0) {
                     $x = count($this->scroller) * 6 + 6;
                 }
-                return [$x -2, $y];
+
+                return [$x - 2, $y];
             });
         }
     }

--- a/example/demo/src/Page/TablePage.php
+++ b/example/demo/src/Page/TablePage.php
@@ -1,28 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Example\Demo\Page;
 
 use PhpTui\Term\Event;
 use PhpTui\Term\Event\CodedKeyEvent;
 use PhpTui\Term\KeyCode;
 use PhpTui\Tui\Example\Demo\Component;
-use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Constraint;
-use PhpTui\Tui\Model\Style;
-use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\Widget\Borders;
-use PhpTui\Tui\Model\Widget\Span;
-use PhpTui\Tui\Model\Widget\Line;
-use PhpTui\Tui\Model\Widget\Title;
 use PhpTui\Tui\Extension\Core\Widget\Block;
 use PhpTui\Tui\Extension\Core\Widget\Table;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableCell;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableRow;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableState;
+use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Constraint;
+use PhpTui\Tui\Model\Style;
+use PhpTui\Tui\Model\Widget;
+use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\Line;
+use PhpTui\Tui\Model\Widget\Span;
+use PhpTui\Tui\Model\Widget\Title;
 
 final class TablePage implements Component
 {
-    const EVENTS = [
+    public const EVENTS = [
         ['Event1', 'INFO'],
         ['Event2', 'INFO'],
         ['Event3', 'CRITICAL'],

--- a/example/docs/getting-started/map.php
+++ b/example/docs/getting-started/map.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Extension\Core\Shape\Map;
 use PhpTui\Tui\Extension\Core\Shape\MapResolution;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/circle.php
+++ b/example/docs/shape/circle.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Shape\Circle;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Extension\Core\Shape\Circle;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/closureShape.php
+++ b/example/docs/shape/closureShape.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Model\Widget\Line;
+use PhpTui\Tui\Extension\Core\Shape\ClosureShape;
 use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Canvas\Painter;
-use PhpTui\Tui\Extension\Core\Shape\ClosureShape;
+use PhpTui\Tui\Model\Marker;
+use PhpTui\Tui\Model\Widget\Line;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/imageShape.php
+++ b/example/docs/shape/imageShape.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Extension\ImageMagick\ImageMagickExtension;
 use PhpTui\Tui\Extension\ImageMagick\Shape\ImageShape;
 use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/line.php
+++ b/example/docs/shape/line.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Shape\Line;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Extension\Core\Shape\Line;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/map.php
+++ b/example/docs/shape/map.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Extension\Core\Shape\Map;
 use PhpTui\Tui\Extension\Core\Shape\MapResolution;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Marker;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/points.php
+++ b/example/docs/shape/points.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Shape\Points;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Extension\Core\Shape\Points;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/rectangle.php
+++ b/example/docs/shape/rectangle.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Shape\Rectangle;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Extension\Core\Shape\Rectangle;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/sprite.php
+++ b/example/docs/shape/sprite.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Shape\Sprite;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Extension\Core\Shape\Sprite;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/shape/textShape.php
+++ b/example/docs/shape/textShape.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
 use PhpTui\Tui\Extension\Bdf\BdfExtension;
 use PhpTui\Tui\Extension\Bdf\FontRegistry;
 use PhpTui\Tui\Extension\Bdf\Shape\TextShape;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/widget/block.php
+++ b/example/docs/widget/block.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Widget\BorderType;
-use PhpTui\Tui\Model\Widget\Borders;
-use PhpTui\Tui\Model\Widget\Text;
-use PhpTui\Tui\Model\Widget\Title;
 use PhpTui\Tui\Extension\Core\Widget\Block;
 use PhpTui\Tui\Extension\Core\Widget\Paragraph;
+use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\BorderType;
+use PhpTui\Tui\Model\Widget\Text;
+use PhpTui\Tui\Model\Widget\Title;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/widget/canvas.php
+++ b/example/docs/widget/canvas.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Extension\Core\Shape\Circle;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
+use PhpTui\Tui\Model\Marker;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/widget/chart.php
+++ b/example/docs/widget/chart.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\AxisBounds;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Model\Widget\Span;
 use PhpTui\Tui\Extension\Core\Widget\Chart;
 use PhpTui\Tui\Extension\Core\Widget\Chart\Axis;
 use PhpTui\Tui\Extension\Core\Widget\Chart\DataSet;
 use PhpTui\Tui\Extension\Core\Widget\Chart\GraphType;
+use PhpTui\Tui\Model\AxisBounds;
+use PhpTui\Tui\Model\Marker;
+use PhpTui\Tui\Model\Widget\Span;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/widget/grid.php
+++ b/example/docs/widget/grid.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Grid;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Widget\Borders;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Grid;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/widget/itemList.php
+++ b/example/docs/widget/itemList.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Widget\Text;
 use PhpTui\Tui\Extension\Core\Widget\ItemList;
 use PhpTui\Tui\Extension\Core\Widget\ItemList\ItemListState;
 use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
+use PhpTui\Tui\Model\Widget\Text;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/widget/paragraph.php
+++ b/example/docs/widget/paragraph.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Widget\Text;
 use PhpTui\Tui\Extension\Core\Widget\Paragraph;
+use PhpTui\Tui\Model\Widget\Text;
 
 require 'vendor/autoload.php';
 

--- a/example/docs/widget/table.php
+++ b/example/docs/widget/table.php
@@ -2,10 +2,10 @@
 <?php
 
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Extension\Core\Widget\Table;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableCell;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableRow;
+use PhpTui\Tui\Model\Constraint;
 
 require 'vendor/autoload.php';
 

--- a/example/misc/inline.php
+++ b/example/misc/inline.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget\Borders;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 
 require 'vendor/autoload.php';
 

--- a/lib/bdf/src/BdfBoundingBox.php
+++ b/lib/bdf/src/BdfBoundingBox.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 final class BdfBoundingBox

--- a/lib/bdf/src/BdfCoord.php
+++ b/lib/bdf/src/BdfCoord.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 final class BdfCoord

--- a/lib/bdf/src/BdfFont.php
+++ b/lib/bdf/src/BdfFont.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 use RuntimeException;

--- a/lib/bdf/src/BdfGlyph.php
+++ b/lib/bdf/src/BdfGlyph.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 final class BdfGlyph

--- a/lib/bdf/src/BdfMetadata.php
+++ b/lib/bdf/src/BdfMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 final class BdfMetadata

--- a/lib/bdf/src/BdfParser.php
+++ b/lib/bdf/src/BdfParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 use RuntimeException;
@@ -103,6 +105,7 @@ final class BdfParser
             $tokens->advance();
             if ($propertyName === BdfToken::COMMENT->name) {
                 $tokens->parseLine();
+
                 continue;
             }
             $values = $this->parseValue($tokens);

--- a/lib/bdf/src/BdfProperties.php
+++ b/lib/bdf/src/BdfProperties.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 final class BdfProperties

--- a/lib/bdf/src/BdfProperty.php
+++ b/lib/bdf/src/BdfProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 enum BdfProperty

--- a/lib/bdf/src/BdfResult.php
+++ b/lib/bdf/src/BdfResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 /**

--- a/lib/bdf/src/BdfSize.php
+++ b/lib/bdf/src/BdfSize.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 final class BdfSize

--- a/lib/bdf/src/BdfToken.php
+++ b/lib/bdf/src/BdfToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 enum BdfToken

--- a/lib/bdf/src/BdfTokenStream.php
+++ b/lib/bdf/src/BdfTokenStream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\BDF;
 
 use Closure;
@@ -63,6 +65,7 @@ final class BdfTokenStream
         );
         $this->skipWhitespace();
         $this->skipComments();
+
         return $taken;
     }
 
@@ -81,6 +84,7 @@ final class BdfTokenStream
             $this->advance();
             $this->skipWhitespace();
             $this->skipComments();
+
             return $int;
         }
 

--- a/lib/bdf/tests/BdfParserTest.php
+++ b/lib/bdf/tests/BdfParserTest.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Bdf\Tests;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\BDF\BdfBoundingBox;
 use PhpTui\BDF\BdfCoord;
 use PhpTui\BDF\BdfGlyph;
@@ -10,6 +11,7 @@ use PhpTui\BDF\BdfMetadata;
 use PhpTui\BDF\BdfParser;
 use PhpTui\BDF\BdfProperty;
 use PhpTui\BDF\BdfSize;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class BdfParserTest extends TestCase

--- a/lib/bdf/tests/Benchmark/BdfParserBench.php
+++ b/lib/bdf/tests/Benchmark/BdfParserBench.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Bdf\Tests\Benchmark;
 
-use RuntimeException;
-use PhpTui\BDF\BdfParser;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
+use PhpTui\BDF\BdfParser;
+use RuntimeException;
 
 #[Iterations(10)]
 #[Revs(25)]

--- a/lib/docgen/src/Docgen.php
+++ b/lib/docgen/src/Docgen.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Docgen;
 
 use Generator;
@@ -11,8 +13,8 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
-use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Canvas\Shape;
+use PhpTui\Tui\Model\Widget;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
@@ -48,7 +50,7 @@ final class Docgen
     {
         $astLocator = (new BetterReflection())->astLocator();
         $reflector  = new DefaultReflector(new AggregateSourceLocator([
-            (new MakeLocatorForComposerJson)($cwd, $astLocator),
+            (new MakeLocatorForComposerJson())($cwd, $astLocator),
             new PhpInternalSourceLocator($astLocator, new ReflectionSourceStubber())
         ]));
 
@@ -58,6 +60,7 @@ final class Docgen
             new Lexer(),
             (function () {
                 $constExpr = new ConstExprParser();
+
                 return new PhpDocParser(new TypeParser($constExpr), $constExpr);
             })(),
         );
@@ -90,6 +93,7 @@ final class Docgen
                             )
                         );
                     }
+
                     return new WidgetParam(
                         type: $type ? $type : $phpType,
                         name: $prop->getName(),
@@ -128,6 +132,7 @@ final class Docgen
                             )
                         );
                     }
+
                     return new WidgetParam(
                         type: $type ? $type : $phpType,
                         name: $prop->getName(),
@@ -155,6 +160,7 @@ final class Docgen
             return null;
         }
         $node = $this->parser->parse(new TokenIterator($this->lexer->tokenize($docblock)));
+
         return $node;
     }
 
@@ -169,6 +175,7 @@ final class Docgen
                 $text[] = $child->text;
             }
         }
+
         return str_replace("\n", '', implode(' ', $text));
     }
 
@@ -250,6 +257,7 @@ final class Docgen
                 );
             }
         }
+
         return implode("\n", $doc);
 
     }

--- a/lib/docgen/src/WidgetDoc.php
+++ b/lib/docgen/src/WidgetDoc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Docgen;
 
 final class WidgetDoc

--- a/lib/docgen/src/WidgetParam.php
+++ b/lib/docgen/src/WidgetParam.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Docgen;
 
 class WidgetParam

--- a/lib/term/src/Action.php
+++ b/lib/term/src/Action.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use Stringable;

--- a/lib/term/src/Action/AlternateScreenEnable.php
+++ b/lib/term/src/Action/AlternateScreenEnable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;
@@ -12,6 +14,6 @@ class AlternateScreenEnable implements Action
 
     public function __toString(): string
     {
-        return sprintf('AlternateScreenEnable(%s)', $this->enable ? 'true':'false');
+        return sprintf('AlternateScreenEnable(%s)', $this->enable ? 'true' : 'false');
     }
 }

--- a/lib/term/src/Action/Clear.php
+++ b/lib/term/src/Action/Clear.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Action/CursorShow.php
+++ b/lib/term/src/Action/CursorShow.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;
@@ -12,6 +14,6 @@ final class CursorShow implements Action
 
     public function __toString(): string
     {
-        return sprintf('CursorShow(%s)', $this->show ? 'true':'false');
+        return sprintf('CursorShow(%s)', $this->show ? 'true' : 'false');
     }
 }

--- a/lib/term/src/Action/EnableMouseCapture.php
+++ b/lib/term/src/Action/EnableMouseCapture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;
@@ -12,6 +14,6 @@ class EnableMouseCapture implements Action
 
     public function __toString(): string
     {
-        return sprintf('EnableMouseCapture(%s)', $this->enable ? 'true':'false');
+        return sprintf('EnableMouseCapture(%s)', $this->enable ? 'true' : 'false');
     }
 }

--- a/lib/term/src/Action/MoveCursor.php
+++ b/lib/term/src/Action/MoveCursor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Action/PrintString.php
+++ b/lib/term/src/Action/PrintString.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Action/RequestCursorPosition.php
+++ b/lib/term/src/Action/RequestCursorPosition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Action/Reset.php
+++ b/lib/term/src/Action/Reset.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Action/SetBackgroundColor.php
+++ b/lib/term/src/Action/SetBackgroundColor.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
-use PhpTui\Term\Colors;
 use PhpTui\Term\Action;
+use PhpTui\Term\Colors;
 
 final class SetBackgroundColor implements Action
 {

--- a/lib/term/src/Action/SetForegroundColor.php
+++ b/lib/term/src/Action/SetForegroundColor.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
-use PhpTui\Term\Colors;
 use PhpTui\Term\Action;
+use PhpTui\Term\Colors;
 
 final class SetForegroundColor implements Action
 {

--- a/lib/term/src/Action/SetModifier.php
+++ b/lib/term/src/Action/SetModifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Action/SetRgbBackgroundColor.php
+++ b/lib/term/src/Action/SetRgbBackgroundColor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Action/SetRgbForegroundColor.php
+++ b/lib/term/src/Action/SetRgbForegroundColor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Action;
 
 use PhpTui\Term\Action;

--- a/lib/term/src/Actions.php
+++ b/lib/term/src/Actions.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use PhpTui\Term\Action\AlternateScreenEnable;
 use PhpTui\Term\Action\Clear;
+use PhpTui\Term\Action\CursorShow;
 use PhpTui\Term\Action\EnableMouseCapture;
 use PhpTui\Term\Action\MoveCursor;
+use PhpTui\Term\Action\PrintString;
 use PhpTui\Term\Action\RequestCursorPosition;
 use PhpTui\Term\Action\Reset;
-use PhpTui\Term\Action\SetModifier;
-use PhpTui\Term\Action\CursorShow;
 use PhpTui\Term\Action\SetBackgroundColor;
+use PhpTui\Term\Action\SetForegroundColor;
+use PhpTui\Term\Action\SetModifier;
 use PhpTui\Term\Action\SetRgbBackgroundColor;
 use PhpTui\Term\Action\SetRgbForegroundColor;
-use PhpTui\Term\Action\SetForegroundColor;
-use PhpTui\Term\Action\PrintString;
 
 final class Actions
 {

--- a/lib/term/src/Attribute.php
+++ b/lib/term/src/Attribute.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum Attribute

--- a/lib/term/src/ClearType.php
+++ b/lib/term/src/ClearType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum ClearType

--- a/lib/term/src/Colors.php
+++ b/lib/term/src/Colors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum Colors

--- a/lib/term/src/Colors256.php
+++ b/lib/term/src/Colors256.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use RuntimeException;

--- a/lib/term/src/Event.php
+++ b/lib/term/src/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use Stringable;

--- a/lib/term/src/Event/CharKeyEvent.php
+++ b/lib/term/src/Event/CharKeyEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Event;
 
 use PhpTui\Term\KeyModifiers;

--- a/lib/term/src/Event/CodedKeyEvent.php
+++ b/lib/term/src/Event/CodedKeyEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Event;
 
 use PhpTui\Term\KeyCode;

--- a/lib/term/src/Event/CursorPositionEvent.php
+++ b/lib/term/src/Event/CursorPositionEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Event;
 
 use PhpTui\Term\Event;

--- a/lib/term/src/Event/FocusEvent.php
+++ b/lib/term/src/Event/FocusEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Event;
 
 use PhpTui\Term\Event;

--- a/lib/term/src/Event/FunctionKeyEvent.php
+++ b/lib/term/src/Event/FunctionKeyEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Event;
 
 use PhpTui\Term\KeyEventKind;

--- a/lib/term/src/Event/KeyEvent.php
+++ b/lib/term/src/Event/KeyEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Event;
 
 use PhpTui\Term\Event;

--- a/lib/term/src/Event/MouseEvent.php
+++ b/lib/term/src/Event/MouseEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Event;
 
 use PhpTui\Term\Event;

--- a/lib/term/src/EventParser.php
+++ b/lib/term/src/EventParser.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\Event\CodedKeyEvent;
 use PhpTui\Term\Event\CursorPositionEvent;
 use PhpTui\Term\Event\FocusEvent;
 use PhpTui\Term\Event\FunctionKeyEvent;
-use PhpTui\Term\Event\CodedKeyEvent;
 use PhpTui\Term\Event\MouseEvent;
 
 final class EventParser
@@ -28,6 +30,7 @@ final class EventParser
     {
         $events = $this->events;
         $this->events = [];
+
         return $events;
     }
 
@@ -40,10 +43,12 @@ final class EventParser
             $more = $index + 1 < strlen($line) || $more;
 
             $this->buffer[] = $byte;
+
             try {
                 $event = $this->parseEvent($this->buffer, $more);
             } catch (ParseError $error) {
                 $this->buffer = [];
+
                 continue;
             }
             if ($event === null) {
@@ -199,6 +204,7 @@ final class EventParser
         if (null !== $keycode) {
             return CodedKeyEvent::new($keycode);
         }
+
         return match($first) {
             11,12,13,14,15 => FunctionKeyEvent::new($first - 10),
             17,18,19,20,21 => FunctionKeyEvent::new($first - 11),
@@ -224,6 +230,7 @@ final class EventParser
             throw new ParseError('Multibyte characters not supported');
         }
         $char = $buffer[0];
+
         return $this->charToEvent($char);
     }
 
@@ -306,8 +313,10 @@ final class EventParser
             if (null === $kindCode) {
                 return null;
             }
+
             return [$modifierMask, $kindCode];
         }
+
         return [$modifierMask, 1];
     }
 
@@ -319,6 +328,7 @@ final class EventParser
                 if (false === is_numeric($char)) {
                     return $ac;
                 }
+
                 return $ac . $char;
             },
             ''
@@ -326,7 +336,8 @@ final class EventParser
         if ($str === '') {
             return null;
         }
-        return intval($str);
+
+        return (int) $str;
     }
 
     /**
@@ -354,6 +365,7 @@ final class EventParser
         if (($modifierMask & 32) !== 0) {
             $modifiers |= KeyModifiers::META;
         }
+
         return $modifiers;
     }
 
@@ -385,8 +397,8 @@ final class EventParser
         // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
         // The upper left character position on the terminal is denoted as 1,1.
         // Subtract 1 to keep it synced with cursor
-        $cx = max(0, ord($buffer[4])- 32) - 1;
-        $cy = max(0, ord($buffer[5])- 32) - 1;
+        $cx = max(0, ord($buffer[4]) - 32) - 1;
+        $cy = max(0, ord($buffer[5]) - 32) - 1;
 
         return MouseEvent::new($kind, $button, $cx, $cy, $modifiers);
     }
@@ -459,9 +471,9 @@ final class EventParser
                 $s
             ));
         }
-        [$kind, $modifiers, $button] = $this->parseCb(intval($split[0]) - 32);
-        $cx = intval($split[1]) - 1;
-        $cy = intval($split[2]) - 1;
+        [$kind, $modifiers, $button] = $this->parseCb((int) ($split[0]) - 32);
+        $cx = (int) ($split[1]) - 1;
+        $cy = (int) ($split[2]) - 1;
 
         return MouseEvent::new(
             $kind,
@@ -483,9 +495,9 @@ final class EventParser
         }
         $s = implode('', array_slice($buffer, 3, -1));
         $split = explode(';', $s);
-        [$kind, $modifiers, $button] = $this->parseCb(intval($split[0]));
-        $cx = intval($split[1]) - 1;
-        $cy = intval($split[2]) - 1;
+        [$kind, $modifiers, $button] = $this->parseCb((int) ($split[0]));
+        $cx = (int) ($split[1]) - 1;
+        $cy = (int) ($split[2]) - 1;
 
         if ($lastChar === 'm') {
             $kind = match ($kind) {
@@ -493,6 +505,7 @@ final class EventParser
                 default => $kind,
             };
         }
+
         return MouseEvent::new(
             $kind,
             $button,
@@ -512,9 +525,10 @@ final class EventParser
         if (count($split) !== 2) {
             return null;
         }
+
         return new CursorPositionEvent(
-            intval($split[1]) - 1,
-            intval($split[0]) - 1,
+            (int) ($split[1]) - 1,
+            (int) ($split[0]) - 1,
         );
     }
 }

--- a/lib/term/src/EventProvider.php
+++ b/lib/term/src/EventProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 interface EventProvider

--- a/lib/term/src/EventProvider/LoadedEventProvider.php
+++ b/lib/term/src/EventProvider/LoadedEventProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\EventProvider;
 
 use PhpTui\Term\Event;

--- a/lib/term/src/EventProvider/SyncEventProvider.php
+++ b/lib/term/src/EventProvider/SyncEventProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\EventProvider;
 
 use PhpTui\Term\Event;

--- a/lib/term/src/Focus.php
+++ b/lib/term/src/Focus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum Focus

--- a/lib/term/src/InformationProvider.php
+++ b/lib/term/src/InformationProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 interface InformationProvider

--- a/lib/term/src/InformationProvider/AggregateInformationProvider.php
+++ b/lib/term/src/InformationProvider/AggregateInformationProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\InformationProvider;
 
 use PhpTui\Term\InformationProvider;

--- a/lib/term/src/InformationProvider/ClosureInformationProvider.php
+++ b/lib/term/src/InformationProvider/ClosureInformationProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\InformationProvider;
 
 use Closure;

--- a/lib/term/src/InformationProvider/SizeFromEnvVarProvider.php
+++ b/lib/term/src/InformationProvider/SizeFromEnvVarProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\InformationProvider;
 
 use PhpTui\Term\InformationProvider;
@@ -22,7 +24,7 @@ class SizeFromEnvVarProvider implements InformationProvider
         }
 
         /** @phpstan-ignore-next-line */
-        return new Size(intval($lines), intval($cols));
+        return new Size((int) $lines, (int) $cols);
     }
 
     public static function new(): self

--- a/lib/term/src/InformationProvider/SizeFromSttyProvider.php
+++ b/lib/term/src/InformationProvider/SizeFromSttyProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\InformationProvider;
 
 use PhpTui\Term\InformationProvider;
@@ -28,6 +30,7 @@ final class SizeFromSttyProvider implements InformationProvider
         if (null === $out) {
             return null;
         }
+
         /**
          * @phpstan-ignore-next-line */
         return $this->parse($out);
@@ -50,6 +53,6 @@ final class SizeFromSttyProvider implements InformationProvider
             return null;
         }
 
-        return new Size(intval($matches[1]), intval($matches[2]));
+        return new Size((int) ($matches[1]), (int) ($matches[2]));
     }
 }

--- a/lib/term/src/KeyCode.php
+++ b/lib/term/src/KeyCode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum KeyCode

--- a/lib/term/src/KeyEventKind.php
+++ b/lib/term/src/KeyEventKind.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum KeyEventKind

--- a/lib/term/src/KeyModifiers.php
+++ b/lib/term/src/KeyModifiers.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 final class KeyModifiers
 {
-    const SHIFT = 0b0000_0001;
-    const CONTROL = 0b0000_0010;
-    const ALT = 0b0000_0100;
-    const SUPER = 0b0000_1000;
-    const HYPER = 0b0001_0000;
-    const META = 0b0010_0000;
-    const NONE = 0b0000_0000;
+    public const SHIFT = 0b0000_0001;
+    public const CONTROL = 0b0000_0010;
+    public const ALT = 0b0000_0100;
+    public const SUPER = 0b0000_1000;
+    public const HYPER = 0b0001_0000;
+    public const META = 0b0010_0000;
+    public const NONE = 0b0000_0000;
 
     /**
      * @param int-mask-of<KeyModifiers::*> $modifierMask
@@ -39,6 +41,7 @@ final class KeyModifiers
         if (($modifierMask & self::META) !== 0) {
             $modifiers[] = 'meta';
         }
+
         return implode(',', $modifiers);
     }
 }

--- a/lib/term/src/MouseButton.php
+++ b/lib/term/src/MouseButton.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum MouseButton

--- a/lib/term/src/MouseEventKind.php
+++ b/lib/term/src/MouseEventKind.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 enum MouseEventKind

--- a/lib/term/src/Painter.php
+++ b/lib/term/src/Painter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 interface Painter

--- a/lib/term/src/Painter/AnsiPainter.php
+++ b/lib/term/src/Painter/AnsiPainter.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Painter;
 
+use PhpTui\Term\Action;
 use PhpTui\Term\Action\AlternateScreenEnable;
 use PhpTui\Term\Action\Clear;
 use PhpTui\Term\Action\CursorShow;
@@ -15,11 +18,10 @@ use PhpTui\Term\Action\SetForegroundColor;
 use PhpTui\Term\Action\SetModifier;
 use PhpTui\Term\Action\SetRgbBackgroundColor;
 use PhpTui\Term\Action\SetRgbForegroundColor;
-use PhpTui\Term\ClearType;
-use PhpTui\Term\Painter;
-use PhpTui\Term\Colors;
-use PhpTui\Term\Action;
 use PhpTui\Term\Attribute;
+use PhpTui\Term\ClearType;
+use PhpTui\Term\Colors;
+use PhpTui\Term\Painter;
 use PhpTui\Term\Writer;
 use RuntimeException;
 
@@ -45,14 +47,17 @@ final class AnsiPainter implements Painter
     {
         if ($action instanceof PrintString) {
             $this->writer->write($action->string);
+
             return;
         }
         if ($action instanceof SetForegroundColor && $action->color === Colors::Reset) {
             $this->writer->write($this->esc('39m'));
+
             return;
         }
         if ($action instanceof SetBackgroundColor && $action->color === Colors::Reset) {
             $this->writer->write($this->esc('49m'));
+
             return;
         }
 
@@ -76,6 +81,7 @@ final class AnsiPainter implements Painter
                 '?1002h',
                 '?1000h',
             ])));
+
             return;
         }
 

--- a/lib/term/src/Painter/BufferPainter.php
+++ b/lib/term/src/Painter/BufferPainter.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Painter;
 
-use PhpTui\Term\Painter;
 use PhpTui\Term\Action;
+use PhpTui\Term\Painter;
 
 class BufferPainter implements Painter
 {

--- a/lib/term/src/Painter/HtmlCanvasPainter.php
+++ b/lib/term/src/Painter/HtmlCanvasPainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Painter;
 
 use PhpTui\Term\Action;
@@ -75,26 +77,32 @@ class HtmlCanvasPainter implements Painter
         foreach ($actions as $action) {
             if ($action instanceof PrintString) {
                 $this->printString($action);
+
                 continue;
             }
             if ($action instanceof MoveCursor) {
                 $this->cursorX = $action->col - 1;
                 $this->cursorY = $action->line - 1;
+
                 continue;
             }
             if ($action instanceof SetRgbBackgroundColor) {
                 $this->bgColor = $action;
+
                 continue;
             }
             if ($action instanceof SetRgbForegroundColor) {
                 $this->fgColor = $action;
+
                 continue;
             }
             if ($action instanceof Reset) {
                 $this->fgColor = null;
                 $this->bgColor = null;
+
                 continue;
             }
+
             throw new RuntimeException(sprintf(
                 'Do not know how to handle action: %s',
                 $action::class

--- a/lib/term/src/Painter/StringPainter.php
+++ b/lib/term/src/Painter/StringPainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Painter;
 
 use PhpTui\Term\Action\MoveCursor;

--- a/lib/term/src/ParseError.php
+++ b/lib/term/src/ParseError.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use RuntimeException;

--- a/lib/term/src/ProcessResult.php
+++ b/lib/term/src/ProcessResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 final class ProcessResult

--- a/lib/term/src/ProcessRunner.php
+++ b/lib/term/src/ProcessRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 interface ProcessRunner

--- a/lib/term/src/ProcessRunner/ClosureRunner.php
+++ b/lib/term/src/ProcessRunner/ClosureRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\ProcessRunner;
 
 use Closure;

--- a/lib/term/src/ProcessRunner/ProcRunner.php
+++ b/lib/term/src/ProcessRunner/ProcRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\ProcessRunner;
 
 use PhpTui\Term\ProcessResult;

--- a/lib/term/src/RawMode.php
+++ b/lib/term/src/RawMode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 interface RawMode

--- a/lib/term/src/RawMode/NullRawMode.php
+++ b/lib/term/src/RawMode/NullRawMode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\RawMode;
 
 use PhpTui\Term\RawMode;

--- a/lib/term/src/RawMode/SttyRawMode.php
+++ b/lib/term/src/RawMode/SttyRawMode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\RawMode;
 
 use PhpTui\Term\ProcessRunner;

--- a/lib/term/src/Reader.php
+++ b/lib/term/src/Reader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 interface Reader

--- a/lib/term/src/Reader/InMemoryReader.php
+++ b/lib/term/src/Reader/InMemoryReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Reader;
 
 use PhpTui\Term\Reader;

--- a/lib/term/src/Reader/StreamReader.php
+++ b/lib/term/src/Reader/StreamReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Reader;
 
 use PhpTui\Term\Reader;
@@ -18,6 +20,7 @@ final class StreamReader implements Reader
         // TODO: open `/dev/tty` is STDIN is not a TTY
         $resource = STDIN;
         stream_set_blocking($resource, false);
+
         return new self(STDIN);
     }
 

--- a/lib/term/src/Size.php
+++ b/lib/term/src/Size.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use Stringable;

--- a/lib/term/src/Terminal.php
+++ b/lib/term/src/Terminal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 use PhpTui\Term\EventProvider\SyncEventProvider;
@@ -56,6 +58,7 @@ class Terminal
     public function info(string $classFqn): ?object
     {
         $info = $this->infoProvider->for($classFqn);
+
         return $info;
     }
 
@@ -65,6 +68,7 @@ class Terminal
     public function queue(Action $action): self
     {
         $this->queue[] = $action;
+
         return $this;
     }
 
@@ -87,6 +91,7 @@ class Terminal
     {
         $this->painter->paint($this->queue);
         $this->queue = [];
+
         return $this;
     }
 

--- a/lib/term/src/TerminalInformation.php
+++ b/lib/term/src/TerminalInformation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 /**

--- a/lib/term/src/Writer.php
+++ b/lib/term/src/Writer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term;
 
 interface Writer

--- a/lib/term/src/Writer/BufferWriter.php
+++ b/lib/term/src/Writer/BufferWriter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Writer;
 
 use PhpTui\Term\Writer;

--- a/lib/term/src/Writer/StreamWriter.php
+++ b/lib/term/src/Writer/StreamWriter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Writer;
 
 use PhpTui\Term\Writer;

--- a/lib/term/tests/AnsiParserTest.php
+++ b/lib/term/tests/AnsiParserTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests;
 
 use Generator;
-use PHPUnit\Framework\TestCase;
 use PhpTui\Term\Action;
 use PhpTui\Term\Actions;
 use PhpTui\Term\AnsiParser;
+use PHPUnit\Framework\TestCase;
 
 class AnsiParserTest extends TestCase
 {

--- a/lib/term/tests/EventParserTest.php
+++ b/lib/term/tests/EventParserTest.php
@@ -1,22 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests;
 
 use Generator;
-use PHPUnit\Framework\TestCase;
 use PhpTui\Term\Event;
-use PhpTui\Term\EventParser;
 use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\Event\CodedKeyEvent;
 use PhpTui\Term\Event\CursorPositionEvent;
 use PhpTui\Term\Event\FocusEvent;
 use PhpTui\Term\Event\FunctionKeyEvent;
 use PhpTui\Term\Event\MouseEvent;
+use PhpTui\Term\EventParser;
 use PhpTui\Term\KeyCode;
-use PhpTui\Term\Event\CodedKeyEvent;
 use PhpTui\Term\KeyEventKind;
 use PhpTui\Term\KeyModifiers;
 use PhpTui\Term\MouseButton;
 use PhpTui\Term\MouseEventKind;
+use PHPUnit\Framework\TestCase;
 
 class EventParserTest extends TestCase
 {
@@ -34,6 +36,7 @@ class EventParserTest extends TestCase
         $events = $parser->drain();
         if (null === $expected) {
             self::assertCount(0, $events);
+
             return;
         }
         self::assertCount(1, $events);

--- a/lib/term/tests/EventProvider/SyncEventProviderTest.php
+++ b/lib/term/tests/EventProvider/SyncEventProviderTest.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests\EventProvider;
 
-use PHPUnit\Framework\TestCase;
+use PhpTui\Term\Event\CodedKeyEvent;
 use PhpTui\Term\EventParser;
 use PhpTui\Term\EventProvider;
 use PhpTui\Term\EventProvider\SyncEventProvider;
-use PhpTui\Term\Event\CodedKeyEvent;
 use PhpTui\Term\KeyCode;
 use PhpTui\Term\Reader\InMemoryReader;
+use PHPUnit\Framework\TestCase;
 
 class SyncEventProviderTest extends TestCase
 {

--- a/lib/term/tests/InformationProvider/AggregateInformationProviderTest.php
+++ b/lib/term/tests/InformationProvider/AggregateInformationProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests\InformationProvider;
 
 use PhpTui\Term\InformationProvider\AggregateInformationProvider;
@@ -20,6 +22,7 @@ class AggregateInformationProviderTest extends TestCase
                 if ($classFqn !== TestInfo::class) {
                     return null;
                 }
+
                 return $info;
             })
         ]);

--- a/lib/term/tests/InformationProvider/SizeFromEnvVarProviderTest.php
+++ b/lib/term/tests/InformationProvider/SizeFromEnvVarProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests\InformationProvider;
 
 use PhpTui\Term\InformationProvider\SizeFromEnvVarProvider;

--- a/lib/term/tests/InformationProvider/SizeFromSttyProviderTest.php
+++ b/lib/term/tests/InformationProvider/SizeFromSttyProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests\InformationProvider;
 
 use PhpTui\Term\InformationProvider\SizeFromSttyProvider;

--- a/lib/term/tests/Painter/AnsiPainterTest.php
+++ b/lib/term/tests/Painter/AnsiPainterTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests\Painter;
 
+use PhpTui\Term\Action;
+use PhpTui\Term\Actions;
 use PhpTui\Term\ClearType;
 use PhpTui\Term\Colors;
-use PhpTui\Term\Actions;
-use PhpTui\Term\Action;
 use PhpTui\Term\Painter\AnsiPainter;
 use PhpTui\Term\Writer\BufferWriter;
 use PHPUnit\Framework\TestCase;

--- a/lib/term/tests/Painter/HtmlCanvasPainterTest.php
+++ b/lib/term/tests/Painter/HtmlCanvasPainterTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests\Painter;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Term\Actions;
 use PhpTui\Term\Painter\HtmlCanvasPainter;
+use PHPUnit\Framework\TestCase;
 
 class HtmlCanvasPainterTest extends TestCase
 {
@@ -72,6 +74,7 @@ class HtmlCanvasPainterTest extends TestCase
     {
         $normalized = preg_replace('{canvas id=".*?"}', 'canvas id=***', $string);
         $normalized = preg_replace('{getElementById\(".*?"\)}', 'getElementById(***)', (string)$normalized);
+
         return (string)$normalized;
     }
 }

--- a/lib/term/tests/RawMode/SttyRawModeTest.php
+++ b/lib/term/tests/RawMode/SttyRawModeTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests\RawMode;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Term\ProcessResult;
 use PhpTui\Term\ProcessRunner\ClosureRunner;
 use PhpTui\Term\RawMode\SttyRawMode;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class SttyRawModeTest extends TestCase
@@ -16,20 +18,25 @@ class SttyRawModeTest extends TestCase
         $runner = ClosureRunner::new(function (array $command) use (&$called) {
             if ($command === ['stty', '-g']) {
                 $called[] = $command;
+
                 return new ProcessResult(0, 'original mode string', '');
             }
             if ($command === ['stty', 'raw']) {
                 $called[] = $command;
+
                 return new ProcessResult(0, '', '');
             }
             if ($command === ['stty', '-echo']) {
                 $called[] = $command;
+
                 return new ProcessResult(0, '', '');
             }
             if ($command === ['stty', 'original mode string']) {
                 $called[] = $command;
+
                 return new ProcessResult(0, '', '');
             }
+
             throw new RuntimeException(
                 sprintf('Unexpected command: %s', json_encode($command))
             );

--- a/lib/term/tests/TerminalTest.php
+++ b/lib/term/tests/TerminalTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Term\Tests;
 
+use PhpTui\Term\Action;
 use PhpTui\Term\Actions;
 use PhpTui\Term\Colors;
-use PhpTui\Term\Action;
-use PhpTui\Term\Terminal;
 use PhpTui\Term\Painter\BufferPainter;
+use PhpTui\Term\Terminal;
 use PHPUnit\Framework\TestCase;
 
 final class TerminalTest extends TestCase

--- a/src/Bridge/Cassowary/CassowaryConstraintSolver.php
+++ b/src/Bridge/Cassowary/CassowaryConstraintSolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Bridge\Cassowary;
 
 use PhpTui\Cassowary\Constraint;
@@ -8,11 +10,11 @@ use PhpTui\Cassowary\Strength;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Areas;
 use PhpTui\Tui\Model\Constraint as DTLConstraint;
-use PhpTui\Tui\Model\ConstraintSolver;
 use PhpTui\Tui\Model\Constraint\LengthConstraint;
 use PhpTui\Tui\Model\Constraint\MaxConstraint;
 use PhpTui\Tui\Model\Constraint\MinConstraint;
 use PhpTui\Tui\Model\Constraint\PercentageConstraint;
+use PhpTui\Tui\Model\ConstraintSolver;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Layout;
 use RuntimeException;
@@ -47,6 +49,7 @@ final class CassowaryConstraintSolver implements ConstraintSolver
         foreach ($elements as $element) {
             if ($previousElement === null) {
                 $previousElement = $element;
+
                 continue;
             }
             $solver->addConstraint(
@@ -76,8 +79,8 @@ final class CassowaryConstraintSolver implements ConstraintSolver
 
         return new Areas(array_map(function (Element $element) use ($changes, $layout, $inner) {
             $values = $changes->getValues($element->start, $element->end);
-            $start = intval($values[0]);
-            $end = intval($values[1]);
+            $start = (int) ($values[0]);
+            $end = (int) ($values[1]);
             $size = $end - $start;
 
             return match ($layout->direction) {
@@ -107,6 +110,7 @@ final class CassowaryConstraintSolver implements ConstraintSolver
                 $areaSize * ($constraint->percentage / 100.0),
                 Strength::STRONG
             );
+
             return [
                 $constraint
             ];

--- a/src/Bridge/Cassowary/Element.php
+++ b/src/Bridge/Cassowary/Element.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Bridge\Cassowary;
 
 use PhpTui\Cassowary\Expression;

--- a/src/Bridge/PhpTerm/PhpTermBackend.php
+++ b/src/Bridge/PhpTerm/PhpTermBackend.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Bridge\PhpTerm;
 
 use PhpTui\Term\Action;
@@ -44,6 +46,7 @@ class PhpTermBackend implements Backend
                 'Could not determine terminal size!'
             );
         }
+
         return Area::fromDimensions($size->cols, $size->lines);
     }
 
@@ -119,6 +122,7 @@ class PhpTermBackend implements Backend
             while (null !== $event = $this->terminal->events()->next()) {
                 if ($event instanceof CursorPositionEvent) {
                     $pos = new Position($event->x, $event->y);
+
                     return $pos;
                 }
             }
@@ -264,6 +268,7 @@ class PhpTermBackend implements Backend
         if ($color instanceof RgbColor) {
             return new SetRgbBackgroundColor($color->r, $color->g, $color->b);
         }
+
         throw new RuntimeException(sprintf('Do not know how to set color of type "%s"', $color::class));
     }
 }

--- a/src/DisplayBuilder.php
+++ b/src/DisplayBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui;
 
 use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend;
@@ -14,9 +16,9 @@ use PhpTui\Tui\Model\Viewport;
 use PhpTui\Tui\Model\Viewport\Fixed;
 use PhpTui\Tui\Model\Viewport\Fullscreen;
 use PhpTui\Tui\Model\Viewport\Inline;
+use PhpTui\Tui\Model\Widget\CanvasRenderer;
 use PhpTui\Tui\Model\WidgetRenderer;
 use PhpTui\Tui\Model\WidgetRenderer\AggregateWidgetRenderer;
-use PhpTui\Tui\Model\Widget\CanvasRenderer;
 
 /**
  * An entry point for PHP-TUI.
@@ -85,6 +87,7 @@ final class DisplayBuilder
     public function fullscreen(): self
     {
         $this->viewport = new Fullscreen();
+
         return $this;
     }
 
@@ -95,6 +98,7 @@ final class DisplayBuilder
     public function inline(int $height): self
     {
         $this->viewport = new Inline($height);
+
         return $this;
     }
 
@@ -105,6 +109,7 @@ final class DisplayBuilder
     public function fixed(int $x, int $y, int $width, int $height): self
     {
         $this->viewport = new Fixed(Area::fromScalars($x, $y, $width, $height));
+
         return $this;
     }
 
@@ -121,6 +126,7 @@ final class DisplayBuilder
                 $this->widgetRenderers[] = $widgetRenderers;
             }
         }
+
         return Display::new(
             $this->backend,
             $this->viewport ?? new Fullscreen(),

--- a/src/Extension/Bdf/BdfExtension.php
+++ b/src/Extension/Bdf/BdfExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Bdf;
 
 use PhpTui\Tui\Extension\Bdf\Shape\TextRenderer;

--- a/src/Extension/Bdf/FontRegistry.php
+++ b/src/Extension/Bdf/FontRegistry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Bdf;
 
 use PhpTui\BDF\BdfFont;
@@ -59,6 +61,7 @@ final class FontRegistry
 
         $map = $this->fontMap;
         $map[$name] = $path;
+
         return new self($this->parser, $map);
     }
 

--- a/src/Extension/Bdf/Shape/TextRenderer.php
+++ b/src/Extension/Bdf/Shape/TextRenderer.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Bdf\Shape;
 
 use PhpTui\BDF\BdfGlyph;
 use PhpTui\Tui\Extension\Bdf\FontRegistry;
+use PhpTui\Tui\Model\Canvas\Painter;
 use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Canvas\ShapePainter;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Painter;
 
 class TextRenderer implements ShapePainter
 {
@@ -48,6 +50,7 @@ class TextRenderer implements ShapePainter
             }
             $y++;
         }
+
         return $grid;
     }
 
@@ -85,8 +88,8 @@ class TextRenderer implements ShapePainter
                     continue;
                 }
 
-                for ($yF = $y1; $yF < $y2; $yF+=$yStep) {
-                    for ($xF = $x1; $xF < $x2; $xF+=$xStep) {
+                for ($yF = $y1; $yF < $y2; $yF += $yStep) {
+                    for ($xF = $x1; $xF < $x2; $xF += $xStep) {
                         $point = $painter->getPoint(FloatPosition::at(
                             $charOffset + $shape->position->x + $xF,
                             $shape->position->y + $yF,

--- a/src/Extension/Bdf/Shape/TextShape.php
+++ b/src/Extension/Bdf/Shape/TextShape.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Bdf\Shape;
 
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Shape;
 
 /**
  * Renders text on the canvas.

--- a/src/Extension/Core/CoreExtension.php
+++ b/src/Extension/Core/CoreExtension.php
@@ -1,22 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core;
 
-use PhpTui\Tui\Model\DisplayExtension;
 use PhpTui\Tui\Extension\Core\Shape\CirclePainter;
 use PhpTui\Tui\Extension\Core\Shape\ClosurePainter;
-use PhpTui\Tui\Extension\Core\Shape\SpritePainter;
-use PhpTui\Tui\Extension\Core\Shape\RectanglePainter;
-use PhpTui\Tui\Extension\Core\Shape\PointsPainter;
-use PhpTui\Tui\Extension\Core\Shape\MapPainter;
 use PhpTui\Tui\Extension\Core\Shape\LinePainter;
+use PhpTui\Tui\Extension\Core\Shape\MapPainter;
+use PhpTui\Tui\Extension\Core\Shape\PointsPainter;
+use PhpTui\Tui\Extension\Core\Shape\RectanglePainter;
+use PhpTui\Tui\Extension\Core\Shape\SpritePainter;
 use PhpTui\Tui\Extension\Core\Widget\BlockRenderer;
-use PhpTui\Tui\Extension\Core\Widget\RawWidgetRenderer;
-use PhpTui\Tui\Extension\Core\Widget\ItemListRenderer;
-use PhpTui\Tui\Extension\Core\Widget\GridRenderer;
 use PhpTui\Tui\Extension\Core\Widget\ChartRenderer;
+use PhpTui\Tui\Extension\Core\Widget\GridRenderer;
+use PhpTui\Tui\Extension\Core\Widget\ItemListRenderer;
 use PhpTui\Tui\Extension\Core\Widget\ParagraphRenderer;
+use PhpTui\Tui\Extension\Core\Widget\RawWidgetRenderer;
 use PhpTui\Tui\Extension\Core\Widget\TableRenderer;
+use PhpTui\Tui\Model\DisplayExtension;
 
 class CoreExtension implements DisplayExtension
 {

--- a/src/Extension/Core/Shape/Circle.php
+++ b/src/Extension/Core/Shape/Circle.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Shape;
 
 /**
  * Draws a circle at with the specified radius and color
@@ -36,6 +38,7 @@ final class Circle implements Shape
     public function color(Color $color): self
     {
         $this->color = $color;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Shape/CirclePainter.php
+++ b/src/Extension/Core/Shape/CirclePainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\Canvas\Painter;

--- a/src/Extension/Core/Shape/ClosurePainter.php
+++ b/src/Extension/Core/Shape/ClosurePainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\Canvas\Painter;

--- a/src/Extension/Core/Shape/ClosureShape.php
+++ b/src/Extension/Core/Shape/ClosureShape.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use Closure;

--- a/src/Extension/Core/Shape/Data/MapData.php
+++ b/src/Extension/Core/Shape/Data/MapData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape\Data;
 
 class MapData

--- a/src/Extension/Core/Shape/DefaultShapeSet.php
+++ b/src/Extension/Core/Shape/DefaultShapeSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\Canvas\ShapeSet;

--- a/src/Extension/Core/Shape/Line.php
+++ b/src/Extension/Core/Shape/Line.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Shape;
 
 /**
  * Draw a straight line from one point to another.
@@ -40,6 +42,7 @@ class Line implements Shape
     public function color(Color $color): self
     {
         $this->color = $color;
+
         return $this;
     }
 

--- a/src/Extension/Core/Shape/LinePainter.php
+++ b/src/Extension/Core/Shape/LinePainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\Canvas\Painter;
@@ -33,6 +35,7 @@ class LinePainter implements ShapePainter
             foreach ($yRange as $y) {
                 $painter->paint($point1->withY($y), $shape->color);
             }
+
             return;
         }
 
@@ -40,19 +43,23 @@ class LinePainter implements ShapePainter
             foreach ($xRange as $x) {
                 $painter->paint($point1->withX($x), $shape->color);
             }
+
             return;
         }
 
         if ($diffY < $diffX) {
             if ($point1->x > $point2->x) {
                 $this->drawLineLow($painter, $shape, $point2, $point1);
+
                 return;
             }
             $this->drawLineLow($painter, $shape, $point1, $point2);
+
             return;
         }
         if ($point1->y > $point2->y) {
             $this->drawLineHigh($painter, $shape, $point2, $point1);
+
             return;
         }
 
@@ -67,6 +74,7 @@ class LinePainter implements ShapePainter
         if ($end >= $start) {
             return [$end - $start, range($start, $end)];
         }
+
         return [$start - $end, range($end, $start)];
     }
 

--- a/src/Extension/Core/Shape/Map.php
+++ b/src/Extension/Core/Shape/Map.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Canvas\Shape;
+use PhpTui\Tui\Model\Color;
 
 /**
  * Renders a map of the world!
@@ -26,6 +28,7 @@ class Map implements Shape
     public function resolution(MapResolution $resolution): self
     {
         $this->mapResolution = $resolution;
+
         return $this;
     }
 
@@ -37,6 +40,7 @@ class Map implements Shape
     public function color(Color $color): self
     {
         $this->color = $color;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Shape/MapPainter.php
+++ b/src/Extension/Core/Shape/MapPainter.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
-use PhpTui\Tui\Model\Canvas\ShapePainter;
-use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Model\Canvas\Painter;
 use PhpTui\Tui\Model\Canvas\Shape;
+use PhpTui\Tui\Model\Canvas\ShapePainter;
+use PhpTui\Tui\Model\Widget\FloatPosition;
 
 class MapPainter implements ShapePainter
 {

--- a/src/Extension/Core/Shape/MapResolution.php
+++ b/src/Extension/Core/Shape/MapResolution.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Extension\Core\Shape\Data\MapData;

--- a/src/Extension/Core/Shape/NullShapePainter.php
+++ b/src/Extension/Core/Shape/NullShapePainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\Canvas\Painter;

--- a/src/Extension/Core/Shape/Points.php
+++ b/src/Extension/Core/Shape/Points.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
-use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Canvas\Shape;
+use PhpTui\Tui\Model\Color;
 
 /**
  * Render a set of points on the canvas.

--- a/src/Extension/Core/Shape/PointsPainter.php
+++ b/src/Extension/Core/Shape/PointsPainter.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
-use PhpTui\Tui\Model\Canvas\ShapePainter;
-use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Model\Canvas\Painter;
 use PhpTui\Tui\Model\Canvas\Shape;
+use PhpTui\Tui\Model\Canvas\ShapePainter;
+use PhpTui\Tui\Model\Widget\FloatPosition;
 
 class PointsPainter implements ShapePainter
 {

--- a/src/Extension/Core/Shape/Rectangle.php
+++ b/src/Extension/Core/Shape/Rectangle.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
 use PhpTui\Tui\Model\AnsiColor;
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Shape;
 
 /**
  * Draw a rectangle at the given position with the given width and height
@@ -40,6 +42,7 @@ final class Rectangle implements Shape
     public function color(Color $color): self
     {
         $this->color = $color;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Shape/RectanglePainter.php
+++ b/src/Extension/Core/Shape/RectanglePainter.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
-use PhpTui\Tui\Model\Canvas\ShapePainter;
 use PhpTui\Tui\Model\Canvas\Painter;
 use PhpTui\Tui\Model\Canvas\Shape;
+use PhpTui\Tui\Model\Canvas\ShapePainter;
 
 final class RectanglePainter implements ShapePainter
 {

--- a/src/Extension/Core/Shape/ShapeSet.php
+++ b/src/Extension/Core/Shape/ShapeSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 interface ShapeSet

--- a/src/Extension/Core/Shape/Sprite.php
+++ b/src/Extension/Core/Shape/Sprite.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Shape;
 
 /**
  * Renders a "sprite" based on a given "ascii art"

--- a/src/Extension/Core/Shape/SpritePainter.php
+++ b/src/Extension/Core/Shape/SpritePainter.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Shape;
 
+use PhpTui\Tui\Model\Canvas\Painter;
 use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Canvas\ShapePainter;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Painter;
 
 class SpritePainter implements ShapePainter
 {
@@ -37,8 +39,8 @@ class SpritePainter implements ShapePainter
                 if ($char === $shape->alphaChar) {
                     continue;
                 }
-                for ($yF = $y1; $yF < $y2; $yF+=$yStep) {
-                    for ($xF = $x1; $xF < $x2; $xF+=$xStep) {
+                for ($yF = $y1; $yF < $y2; $yF += $yStep) {
+                    for ($xF = $x1; $xF < $x2; $xF += $xStep) {
                         $point = $painter->getPoint(FloatPosition::at(
                             1 + $shape->position->x + $xF,
                             $shape->position->y + $yF,

--- a/src/Extension/Core/Widget/Block.php
+++ b/src/Extension/Core/Widget/Block.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\Widget\BorderType;
 use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\BorderType;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
 
 /**
  * The block widget is a container for other widgets and can provide a border,
@@ -74,6 +76,7 @@ final class Block implements Widget
     public function widget(Widget $widget): self
     {
         $this->widget = $widget;
+
         return $this;
     }
 
@@ -83,42 +86,49 @@ final class Block implements Widget
     public function borders(int $flag): self
     {
         $this->borders = $flag;
+
         return $this;
     }
 
     public function titles(Title ...$titles): self
     {
         $this->titles = $titles;
+
         return $this;
     }
 
     public function borderType(BorderType $borderType): self
     {
         $this->borderType = $borderType;
+
         return $this;
     }
 
     public function style(Style $style): self
     {
         $this->style = $style;
+
         return $this;
     }
 
     public function borderStyle(Style $style): self
     {
         $this->borderStyle = $style;
+
         return $this;
     }
 
     public function titleStyle(Style $style): self
     {
         $this->titleStyle = $style;
+
         return $this;
     }
 
     public function padding(Padding $padding): self
     {
         $this->padding = $padding;
+
         return $this;
     }
 
@@ -134,7 +144,7 @@ final class Block implements Widget
         }
         if ($this->borders & Borders::TOP || [] !== $this->titles) {
             $y = min($y + 1, $area->bottom());
-            $height = max(0, $height-1);
+            $height = max(0, $height - 1);
         }
         if ($this->borders & Borders::RIGHT) {
             $width = max(0, $width - 1);

--- a/src/Extension/Core/Widget/Block/Padding.php
+++ b/src/Extension/Core/Widget/Block/Padding.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Block;
 
 class Padding

--- a/src/Extension/Core/Widget/BlockRenderer.php
+++ b/src/Extension/Core/Widget/BlockRenderer.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\WidgetRenderer;
 use PhpTui\Tui\Model\Widget\Borders;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\Title;
 use PhpTui\Tui\Model\Widget\VerticalAlignment;
+use PhpTui\Tui\Model\WidgetRenderer;
 
 final class BlockRenderer implements WidgetRenderer
 {
@@ -184,7 +186,7 @@ final class BlockRenderer implements WidgetRenderer
             fn (int $acc, Title $title) => $acc + $title->title->width(),
             0
         );
-        $offset = intval(max(0, $area->width - $sumWidth) / 2);
+        $offset = (int) (max(0, $area->width - $sumWidth) / 2);
         foreach ($titles as $title) {
             $titleX = $offset;
             $offset += $title->title->width() + 1;

--- a/src/Extension/Core/Widget/Canvas.php
+++ b/src/Extension/Core/Widget/Canvas.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use Closure;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\AxisBounds;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Model\Canvas\Shape;
 
 /**
  * The canvas widget provides a surface, of arbitrary scale, upon which shapes can be drawn.
@@ -63,30 +65,35 @@ final class Canvas implements Widget
     public function paint(Closure $closure): self
     {
         $this->painter = $closure;
+
         return $this;
     }
 
     public function xBounds(AxisBounds $axisBounds): self
     {
         $this->xBounds = $axisBounds;
+
         return $this;
     }
 
     public function yBounds(AxisBounds $axisBounds): self
     {
         $this->yBounds = $axisBounds;
+
         return $this;
     }
 
     public function marker(Marker $marker): self
     {
         $this->marker = $marker;
+
         return $this;
     }
 
     public function backgroundColor(Color $color): self
     {
         $this->backgroundColor = $color;
+
         return $this;
     }
 
@@ -116,6 +123,7 @@ final class Canvas implements Widget
         foreach ($shapes as $shape) {
             $this->shapes[] = $shape;
         }
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/Chart.php
+++ b/src/Extension/Core/Widget/Chart.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
-use PhpTui\Tui\Model\Style;
-use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Extension\Core\Widget\Chart\Axis;
 use PhpTui\Tui\Extension\Core\Widget\Chart\DataSet;
+use PhpTui\Tui\Model\Style;
+use PhpTui\Tui\Model\Widget;
 
 /**
  * Renders a a composite of scatter or line graphs.
@@ -49,17 +51,20 @@ final class Chart implements Widget
     public function xAxis(Axis $axis): self
     {
         $this->xAxis = $axis;
+
         return $this;
     }
     public function yAxis(Axis $axis): self
     {
         $this->yAxis = $axis;
+
         return $this;
     }
 
     public function datasets(DataSet ...$dataSets): self
     {
         $this->dataSets = $dataSets;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/Chart/Axis.php
+++ b/src/Extension/Core/Widget/Chart/Axis.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Chart;
 
 use PhpTui\Tui\Model\AxisBounds;
@@ -23,6 +25,7 @@ final class Axis
     public function style(Style $style): self
     {
         $this->style = $style;
+
         return $this;
     }
 
@@ -32,12 +35,14 @@ final class Axis
     public function labels(array $labels): self
     {
         $this->labels = $labels;
+
         return $this;
     }
 
     public function bounds(AxisBounds $bounds): self
     {
         $this->bounds = $bounds;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/Chart/ChartLayout.php
+++ b/src/Extension/Core/Widget/Chart/ChartLayout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Chart;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Extension/Core/Widget/Chart/DataSet.php
+++ b/src/Extension/Core/Widget/Chart/DataSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Chart;
 
 use PhpTui\Tui\Model\Marker;
@@ -33,12 +35,14 @@ final class DataSet
     public function marker(Marker $marker): self
     {
         $this->marker = $marker;
+
         return $this;
     }
 
     public function style(Style $style): self
     {
         $this->style = $style;
+
         return $this;
     }
 
@@ -48,12 +52,14 @@ final class DataSet
     public function data(array $data): self
     {
         $this->data = $data;
+
         return $this;
     }
 
     public function graphType(GraphType $graphType): self
     {
         $this->graphType = $graphType;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/Chart/GraphType.php
+++ b/src/Extension/Core/Widget/Chart/GraphType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Chart;
 
 enum GraphType

--- a/src/Extension/Core/Widget/ChartRenderer.php
+++ b/src/Extension/Core/Widget/ChartRenderer.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Shape\Points;
+use PhpTui\Tui\Extension\Core\Widget\Chart\ChartLayout;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\WidgetRenderer;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\LineSet;
 use PhpTui\Tui\Model\Widget\Span;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Shape\Points;
-use PhpTui\Tui\Extension\Core\Widget\Chart\ChartLayout;
+use PhpTui\Tui\Model\WidgetRenderer;
 use RuntimeException;
 
 /**
@@ -145,7 +147,7 @@ final class ChartRenderer implements WidgetRenderer
         if (count($labels) < 2) {
             return;
         }
-        $widthBetweenTicks = intval($layout->graphArea->width / count($labels));
+        $widthBetweenTicks = (int) ($layout->graphArea->width / count($labels));
         $labelAlignment = match ($chart->xAxis->labelAlignment) {
             HorizontalAlignment::Left => HorizontalAlignment::Right,
             HorizontalAlignment::Center => HorizontalAlignment::Center,
@@ -170,7 +172,7 @@ final class ChartRenderer implements WidgetRenderer
         }
         foreach ($labels as $i => $label) {
             $x = $layout->graphArea->left() + ($i + 1) * $widthBetweenTicks + 1;
-            $labelArea = Area::fromScalars($x, $layout->labelX, $widthBetweenTicks -1, 1);
+            $labelArea = Area::fromScalars($x, $layout->labelX, $widthBetweenTicks - 1, 1);
             self::renderLabel($buffer, $label, $labelArea, HorizontalAlignment::Center);
         }
         $x = $layout->graphArea->right() - $widthBetweenTicks;
@@ -202,7 +204,7 @@ final class ChartRenderer implements WidgetRenderer
             HorizontalAlignment::Right => $labelArea->right() - $boundedLabelWidth,
         };
 
-        $buffer->putSpan(Position::at(intval($x), $labelArea->top()), $label, $boundedLabelWidth);
+        $buffer->putSpan(Position::at((int) $x, $labelArea->top()), $label, $boundedLabelWidth);
     }
 
     private function renderYLabels(Chart $chart, Buffer $buffer, ChartLayout $layout, Area $chartArea): void
@@ -216,7 +218,7 @@ final class ChartRenderer implements WidgetRenderer
         }
         $labelsLen = count($labels);
         foreach ($labels as $i => $label) {
-            $dy = intval($i * ($layout->graphArea->height - 1) / ($labelsLen - 1));
+            $dy = (int) ($i * ($layout->graphArea->height - 1) / ($labelsLen - 1));
             if ($dy < $layout->graphArea->bottom()) {
                 $labelArea = Area::fromScalars(
                     $layout->labelY,

--- a/src/Extension/Core/Widget/ClosureRenderer.php
+++ b/src/Extension/Core/Widget/ClosureRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use Closure;

--- a/src/Extension/Core/Widget/DefaultWidgetSet.php
+++ b/src/Extension/Core/Widget/DefaultWidgetSet.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
-use PhpTui\Tui\Model\Widget\CanvasRenderer;
 use PhpTui\Tui\Model\Canvas\ShapePainter;
+use PhpTui\Tui\Model\Widget\CanvasRenderer;
 use PhpTui\Tui\Model\WidgetSet;
 
 class DefaultWidgetSet implements WidgetSet

--- a/src/Extension/Core/Widget/Grid.php
+++ b/src/Extension/Core/Widget/Grid.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use PhpTui\Tui\Model\Constraint;
@@ -45,18 +47,21 @@ class Grid implements Widget
     public function direction(Direction $direction): self
     {
         $this->direction = $direction;
+
         return $this;
     }
 
     public function constraints(Constraint ...$constraints): self
     {
         $this->constraints = array_values($constraints);
+
         return $this;
     }
 
     public function widgets(Widget ...$widgets): self
     {
         $this->widgets = array_values($widgets);
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/GridRenderer.php
+++ b/src/Extension/Core/Widget/GridRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Extension/Core/Widget/ItemList.php
+++ b/src/Extension/Core/Widget/ItemList.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Widget\ItemList\HighlightSpacing;
+use PhpTui\Tui\Extension\Core\Widget\ItemList\ItemListState;
+use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
 use PhpTui\Tui\Model\Corner;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\HighlightSpacing;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\ItemListState;
 
 /**
  * The ItemList widget allows you to list and highlight items.
@@ -51,36 +53,42 @@ class ItemList implements Widget
     public function startCorner(Corner $corner): self
     {
         $this->startCorner = $corner;
+
         return $this;
     }
 
     public function select(int $selection): self
     {
         $this->state->selected = $selection;
+
         return $this;
     }
 
     public function offset(int $offset): self
     {
         $this->state->offset = $offset;
+
         return $this;
     }
 
     public function state(ItemListState $state): self
     {
         $this->state = $state;
+
         return $this;
     }
 
     public function highlightSymbol(string $symbol): self
     {
         $this->highlightSymbol = $symbol;
+
         return $this;
     }
 
     public function highlightStyle(Style $highlightStyle): self
     {
         $this->highlightStyle = $highlightStyle;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/ItemList/HighlightSpacing.php
+++ b/src/Extension/Core/Widget/ItemList/HighlightSpacing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\ItemList;
 
 enum HighlightSpacing

--- a/src/Extension/Core/Widget/ItemList/ItemListState.php
+++ b/src/Extension/Core/Widget/ItemList/ItemListState.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\ItemList;
 
 final class ItemListState

--- a/src/Extension/Core/Widget/ItemList/ListItem.php
+++ b/src/Extension/Core/Widget/ItemList/ListItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\ItemList;
 
 use PhpTui\Tui\Model\Style;
@@ -21,6 +23,7 @@ final class ListItem
     public function style(Style $style): self
     {
         $this->style = $style;
+
         return $this;
     }
 

--- a/src/Extension/Core/Widget/ItemListRenderer.php
+++ b/src/Extension/Core/Widget/ItemListRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use PhpTui\Tui\Model\Area;
@@ -35,15 +37,17 @@ class ItemListRenderer implements WidgetRenderer
         $blankSymbol = str_repeat(' ', mb_strlen($highlightSymbol));
         $currentHeight = 0;
         $selectionSpacing = $widget->highlightSpacing->shouldAdd($widget->state->selected !== null);
-        foreach (array_slice($widget->items, $start, $end-$start) as $i => $item) {
+        foreach (array_slice($widget->items, $start, $end - $start) as $i => $item) {
             [$x, $y, $currentHeight] = (function () use ($item, $listArea, $currentHeight, $widget) {
                 if ($widget->startCorner === Corner::BottomLeft) {
                     $currentHeight += $item->height();
+
                     return [$listArea->left(), $listArea->bottom() - $currentHeight, $currentHeight];
                 }
 
                 $y = $listArea->top() + $currentHeight;
                 $currentHeight += $item->height();
+
                 return [$listArea->left(), $y, $currentHeight];
             })();
 

--- a/src/Extension/Core/Widget/Paragraph.php
+++ b/src/Extension/Core/Widget/Paragraph.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Text;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap;
 
 /**
  * This widget has the ability to show and wrap text.
@@ -42,19 +44,22 @@ class Paragraph implements Widget
 
     public function style(Style $style): self
     {
-        $this->style=  $style;
+        $this->style =  $style;
+
         return $this;
     }
 
     public function alignment(HorizontalAlignment $alignment): self
     {
         $this->alignment = $alignment;
+
         return $this;
     }
 
     public function wrap(Wrap $wrap): self
     {
         $this->wrap = $wrap;
+
         return $this;
     }
 

--- a/src/Extension/Core/Widget/Paragraph/Wrap.php
+++ b/src/Extension/Core/Widget/Paragraph/Wrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Paragraph;
 
 final class Wrap

--- a/src/Extension/Core/Widget/ParagraphRenderer.php
+++ b/src/Extension/Core/Widget/ParagraphRenderer.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\LineComposer;
 use PhpTui\Tui\Model\LineComposer\LineTruncator;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\WidgetRenderer;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Span;
 use PhpTui\Tui\Model\Widget\StyledGrapheme;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap;
+use PhpTui\Tui\Model\WidgetRenderer;
 
 class ParagraphRenderer implements WidgetRenderer
 {
@@ -36,8 +38,10 @@ class ParagraphRenderer implements WidgetRenderer
                 foreach ($span->toStyledGraphemes($style) as $grapheme) {
                     $ac[] = $grapheme;
                 }
+
                 return $ac;
             }, []);
+
             return [ $graphemes, $line->alignment ?? $widget->alignment ];
         }, $widget->text->lines);
 
@@ -88,7 +92,7 @@ class ParagraphRenderer implements WidgetRenderer
     private static function getLineOffset(int $width, int $maxWidth, HorizontalAlignment $alignment): int
     {
         return match ($alignment) {
-            HorizontalAlignment::Center => intval(($maxWidth / 2) - $width / 2),
+            HorizontalAlignment::Center => (int) (($maxWidth / 2) - $width / 2),
             HorizontalAlignment::Right => $maxWidth - $width,
             HorizontalAlignment::Left => 0,
         };

--- a/src/Extension/Core/Widget/RawWidget.php
+++ b/src/Extension/Core/Widget/RawWidget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use Closure;

--- a/src/Extension/Core/Widget/RawWidgetRenderer.php
+++ b/src/Extension/Core/Widget/RawWidgetRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Extension/Core/Widget/Table.php
+++ b/src/Extension/Core/Widget/Table.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Widget\ItemList\HighlightSpacing;
+use PhpTui\Tui\Extension\Core\Widget\Table\TableRow;
+use PhpTui\Tui\Extension\Core\Widget\Table\TableState;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\HighlightSpacing;
-use PhpTui\Tui\Extension\Core\Widget\Table\TableRow;
-use PhpTui\Tui\Extension\Core\Widget\Table\TableState;
 
 /**
  * Shows tabular data arranged in columns. The column spacing is determined by
@@ -77,47 +79,55 @@ final class Table implements Widget
     public function header(TableRow $tableRow): self
     {
         $this->header = $tableRow;
+
         return $this;
     }
     public function rows(TableRow ...$rows): self
     {
         $this->rows = array_values($rows);
+
         return $this;
     }
 
     public function widths(Constraint ...$widths): self
     {
         $this->widths = array_values($widths);
+
         return $this;
     }
 
     public function select(int $selection): self
     {
         $this->state->selected = $selection;
+
         return $this;
     }
 
     public function offset(int $offset): self
     {
         $this->state->offset = $offset;
+
         return $this;
     }
 
     public function state(TableState $state): self
     {
         $this->state = $state;
+
         return $this;
     }
 
     public function highlightSymbol(string $symbol): self
     {
         $this->highlightSymbol = $symbol;
+
         return $this;
     }
 
     public function highlightStyle(Style $style): self
     {
         $this->highlightStyle = $style;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/Table/TableCell.php
+++ b/src/Extension/Core/Widget/Table/TableCell.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Table;
 
 use PhpTui\Tui\Model\Style;

--- a/src/Extension/Core/Widget/Table/TableRow.php
+++ b/src/Extension/Core/Widget/Table/TableRow.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Table;
 
 use PhpTui\Tui\Model\Style;
@@ -35,18 +37,21 @@ final class TableRow
         if (!isset($this->cells[$index])) {
             return null;
         }
+
         return $this->cells[$index];
     }
 
     public function bottomMargin(int $bottomMargin): self
     {
         $this->bottomMargin = $bottomMargin;
+
         return $this;
     }
 
     public function height(int $height): self
     {
         $this->height = $height;
+
         return $this;
     }
 }

--- a/src/Extension/Core/Widget/Table/TableState.php
+++ b/src/Extension/Core/Widget/Table/TableState.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget\Table;
 
 class TableState

--- a/src/Extension/Core/Widget/TableRenderer.php
+++ b/src/Extension/Core/Widget/TableRenderer.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Widget\Table\TableCell;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Constraint;
@@ -9,9 +12,8 @@ use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Layout;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\WidgetRenderer;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
-use PhpTui\Tui\Extension\Core\Widget\Table\TableCell;
+use PhpTui\Tui\Model\WidgetRenderer;
 
 final class TableRenderer implements WidgetRenderer
 {
@@ -31,7 +33,7 @@ final class TableRenderer implements WidgetRenderer
             $widget->state->selected !== null
         ) ? mb_strlen($widget->highlightSymbol) : 0;
 
-        $columnWidths = $this->getColumnsWidths($widget, $tableArea->width, intval($selectionWidth));
+        $columnWidths = $this->getColumnsWidths($widget, $tableArea->width, $selectionWidth);
         $highlightSymbol = $widget->highlightSymbol;
         $currentHeight = 0;
         $rowsHeight = $tableArea->height;
@@ -141,6 +143,7 @@ final class TableRenderer implements WidgetRenderer
             $chunk = $chunks->get($i);
             $widths[] = [$chunk->position->x, $chunk->width];
         }
+
         return $widths;
     }
 

--- a/src/Extension/ImageMagick/ImageMagickExtension.php
+++ b/src/Extension/ImageMagick/ImageMagickExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\ImageMagick;
 
 use PhpTui\Tui\Extension\ImageMagick\Shape\ImagePainter;

--- a/src/Extension/ImageMagick/ImageRegistry.php
+++ b/src/Extension/ImageMagick/ImageRegistry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\ImageMagick;
 
 use Imagick;
@@ -39,6 +41,7 @@ final class ImageRegistry
                 $path
             ));
         }
+
         return $image;
     }
 }

--- a/src/Extension/ImageMagick/Shape/ImagePainter.php
+++ b/src/Extension/ImageMagick/Shape/ImagePainter.php
@@ -1,18 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\ImageMagick\Shape;
 
 use ImagickPixel;
+use PhpTui\Tui\Extension\Core\Shape\Line;
 use PhpTui\Tui\Extension\ImageMagick\ImageRegistry;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Canvas\Label;
+use PhpTui\Tui\Model\Canvas\Painter;
+use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Canvas\ShapePainter;
 use PhpTui\Tui\Model\RgbColor;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Model\Canvas\Painter;
-use PhpTui\Tui\Model\Canvas\Shape;
 use PhpTui\Tui\Model\Widget\Line as PhpTuiLine;
-use PhpTui\Tui\Extension\Core\Shape\Line;
 
 final class ImagePainter implements ShapePainter
 {
@@ -53,6 +55,7 @@ final class ImagePainter implements ShapePainter
             $painter->context->labels->add(
                 new Label(FloatPosition::at(0, 0), PhpTuiLine::fromString('Imagick extension not loaded!'))
             );
+
             return;
         }
 
@@ -67,7 +70,7 @@ final class ImagePainter implements ShapePainter
                 $point = $painter->getPoint(
                     FloatPosition::at(
                         $shape->position->x + $x,
-                        $shape->position->y + $geo['height'] - intval($y) - 1
+                        $shape->position->y + $geo['height'] - (int) $y - 1
                     )
                 );
                 if (null === $point) {

--- a/src/Extension/ImageMagick/Shape/ImageShape.php
+++ b/src/Extension/ImageMagick/Shape/ImageShape.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\ImageMagick\Shape;
 
-use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Model\Canvas\Shape;
+use PhpTui\Tui\Model\Widget\FloatPosition;
 use RuntimeException;
 
 /**
@@ -27,6 +29,7 @@ final class ImageShape implements Shape
     public function position(FloatPosition $position): self
     {
         $this->position = $position;
+
         return $this;
     }
 
@@ -38,6 +41,7 @@ final class ImageShape implements Shape
                 $imagePath
             ));
         }
+
         return new self($imagePath, new FloatPosition(0, 0));
     }
 }

--- a/src/Extension/ImageMagick/Widget/ImageRenderer.php
+++ b/src/Extension/ImageMagick/Widget/ImageRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\ImageMagick\Widget;
 
 use PhpTui\Tui\Extension\Core\Widget\Canvas;

--- a/src/Extension/ImageMagick/Widget/ImageWidget.php
+++ b/src/Extension/ImageMagick/Widget/ImageWidget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Extension\ImageMagick\Widget;
 
 use PhpTui\Tui\Model\Marker;

--- a/src/Model/AnsiColor.php
+++ b/src/Model/AnsiColor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 enum AnsiColor: int implements Color

--- a/src/Model/Area.php
+++ b/src/Model/Area.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use Stringable;

--- a/src/Model/Areas.php
+++ b/src/Model/Areas.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use ArrayIterator;

--- a/src/Model/AxisBounds.php
+++ b/src/Model/AxisBounds.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 final class AxisBounds

--- a/src/Model/Backend.php
+++ b/src/Model/Backend.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 interface Backend

--- a/src/Model/Backend/DummyBackend.php
+++ b/src/Model/Backend/DummyBackend.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Backend;
 
 use PhpTui\Tui\Model\Area;
@@ -92,6 +94,7 @@ final class DummyBackend implements Backend
                 }
             }
         }
+
         return $this->grid;
     }
 }

--- a/src/Model/Buffer.php
+++ b/src/Model/Buffer.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use Countable;
+use OutOfBoundsException;
 use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Span;
-use OutOfBoundsException;
 
 final class Buffer implements Countable
 {
@@ -24,6 +26,7 @@ final class Buffer implements Countable
         foreach ($this->content as $cell) {
             $out[] = $cell->__toString();
         }
+
         return implode("\n", $out);
     }
 
@@ -38,6 +41,7 @@ final class Buffer implements Countable
         for ($i = 0; $i < $area->area(); $i++) {
             $content[] = $cell->clone();
         }
+
         return new self($area, $content);
     }
 
@@ -47,7 +51,7 @@ final class Buffer implements Countable
             return;
         }
         foreach (range($area->top(), $area->bottom() - 1) as $y) {
-            foreach (range($area->left(), $area->right() -1) as $x) {
+            foreach (range($area->left(), $area->right() - 1) as $x) {
                 $this->get(Position::at($x, $y))->setStyle($style);
             }
         }
@@ -113,12 +117,14 @@ final class Buffer implements Countable
             }
             $string .= $cell->char;
         }
+
         return $string;
     }
 
     public function putString(Position $position, string $line, ?Style $style = null, int $width = PHP_INT_MAX): Position
     {
         $style = $style ?? Style::default();
+
         try {
             $index = $position->toIndex($this->area);
         } catch (OutOfBoundsException $e) {
@@ -205,8 +211,8 @@ final class Buffer implements Countable
         $bArea = $buffer->area();
 
         foreach ($buffer->content as $bi => $cell) {
-            $y = $position->y + intval(floor($bi / $bArea->width));
-            $x = $position->x + intval($bi % $bArea->width);
+            $y = $position->y + (int) (floor($bi / $bArea->width));
+            $x = $position->x + ($bi % $bArea->width);
             if ($y > $this->area()->height) {
                 continue;
             }

--- a/src/Model/BufferUpdate.php
+++ b/src/Model/BufferUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 final class BufferUpdate

--- a/src/Model/BufferUpdates.php
+++ b/src/Model/BufferUpdates.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use ArrayIterator;
@@ -34,6 +36,7 @@ final class BufferUpdates implements Countable, IteratorAggregate
                 count($this->updates)
             ));
         }
+
         return $this->updates[$index];
     }
 
@@ -44,6 +47,7 @@ final class BufferUpdates implements Countable, IteratorAggregate
                 'Cannot get last update because there are no updates'
             );
         }
+
         return $this->updates[count($this->updates) - 1];
     }
 

--- a/src/Model/Canvas/AggregateShapePainter.php
+++ b/src/Model/Canvas/AggregateShapePainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 /**

--- a/src/Model/Canvas/CanvasContext.php
+++ b/src/Model/Canvas/CanvasContext.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 use PhpTui\Tui\Model\AxisBounds;
+use PhpTui\Tui\Model\Canvas\Grid\BrailleGrid;
+use PhpTui\Tui\Model\Canvas\Grid\CharGrid;
+use PhpTui\Tui\Model\Canvas\Grid\HalfBlockGrid;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\BarSet;
 use PhpTui\Tui\Model\Widget\BlockSet;
 use PhpTui\Tui\Model\Widget\FloatPosition;
 use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Symbols;
-use PhpTui\Tui\Model\Canvas\Grid\BrailleGrid;
-use PhpTui\Tui\Model\Canvas\Grid\CharGrid;
-use PhpTui\Tui\Model\Canvas\Grid\HalfBlockGrid;
 
 final class CanvasContext
 {

--- a/src/Model/Canvas/CanvasGrid.php
+++ b/src/Model/Canvas/CanvasGrid.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 use PhpTui\Tui\Model\Color;

--- a/src/Model/Canvas/FgBgColor.php
+++ b/src/Model/Canvas/FgBgColor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 use PhpTui\Tui\Model\Color;

--- a/src/Model/Canvas/Grid/BrailleGrid.php
+++ b/src/Model/Canvas/Grid/BrailleGrid.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas\Grid;
 
-use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Color;
-use PhpTui\Tui\Model\Position;
-use PhpTui\Tui\Model\Widget\BrailleSet;
 use IntlChar;
+use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Canvas\CanvasGrid;
 use PhpTui\Tui\Model\Canvas\FgBgColor;
 use PhpTui\Tui\Model\Canvas\Layer;
 use PhpTui\Tui\Model\Canvas\Resolution;
+use PhpTui\Tui\Model\Color;
+use PhpTui\Tui\Model\Position;
+use PhpTui\Tui\Model\Widget\BrailleSet;
 
 final class BrailleGrid extends CanvasGrid
 {
@@ -34,6 +36,7 @@ final class BrailleGrid extends CanvasGrid
     public static function new(int $width, int $height): self
     {
         $length = $width * $height;
+
         return new self(
             $width,
             $height,
@@ -66,7 +69,7 @@ final class BrailleGrid extends CanvasGrid
 
     public function paint(Position $position, Color $color): void
     {
-        $index = (intval($position->y / 4)) * $this->width + intval($position->x / 2);
+        $index = ((int) ($position->y / 4)) * $this->width + (int) ($position->x / 2);
         if (isset($this->codePoints[$index])) {
             $this->codePoints[$index] |= BrailleSet::DOTS[$position->y % 4][$position->x % 2];
         }

--- a/src/Model/Canvas/Grid/CharGrid.php
+++ b/src/Model/Canvas/Grid/CharGrid.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas\Grid;
 
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Color;
-use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Canvas\CanvasGrid;
 use PhpTui\Tui\Model\Canvas\FgBgColor;
 use PhpTui\Tui\Model\Canvas\Layer;
 use PhpTui\Tui\Model\Canvas\Resolution;
+use PhpTui\Tui\Model\Color;
+use PhpTui\Tui\Model\Position;
 
 final class CharGrid extends CanvasGrid
 {
@@ -27,6 +29,7 @@ final class CharGrid extends CanvasGrid
     public static function new(int $width, int $height, string $cellChar): self
     {
         $length = $width * $height;
+
         return new self(
             new Resolution($width, $height),
             array_fill(0, $length, ' '),

--- a/src/Model/Canvas/Grid/HalfBlockGrid.php
+++ b/src/Model/Canvas/Grid/HalfBlockGrid.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas\Grid;
 
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Color;
-use PhpTui\Tui\Model\Position;
-use PhpTui\Tui\Model\Widget\BlockSet;
 use PhpTui\Tui\Model\Canvas\CanvasGrid;
 use PhpTui\Tui\Model\Canvas\FgBgColor;
 use PhpTui\Tui\Model\Canvas\Layer;
 use PhpTui\Tui\Model\Canvas\Resolution;
+use PhpTui\Tui\Model\Color;
+use PhpTui\Tui\Model\Position;
+use PhpTui\Tui\Model\Widget\BlockSet;
 
 class HalfBlockGrid extends CanvasGrid
 {
@@ -28,6 +30,7 @@ class HalfBlockGrid extends CanvasGrid
             return new self(new Resolution($width, $height), []);
         }
         $length = $width * $height;
+
         return new self(
             new Resolution($width, $height),
             array_map(
@@ -78,6 +81,7 @@ class HalfBlockGrid extends CanvasGrid
             if ($upper === $lower) {
                 return BlockSet::FULL;
             }
+
             return BlockSet::UPPER_HALF;
         }, $paired);
         $colors = array_map(function (array $pair) {
@@ -94,6 +98,7 @@ class HalfBlockGrid extends CanvasGrid
             if ($upper === AnsiColor::Reset && $lower !== AnsiColor::Reset) {
                 return new FgBgColor($lower, AnsiColor::Reset);
             }
+
             // both set, it will be a block with one color
             return new FgBgColor($upper, $lower);
         }, $paired);

--- a/src/Model/Canvas/Label.php
+++ b/src/Model/Canvas/Label.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 use PhpTui\Tui\Model\Widget\FloatPosition;

--- a/src/Model/Canvas/Labels.php
+++ b/src/Model/Canvas/Labels.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 use ArrayIterator;
-use PhpTui\Tui\Model\AxisBounds;
 use IteratorAggregate;
+use PhpTui\Tui\Model\AxisBounds;
 use Traversable;
 
 /**

--- a/src/Model/Canvas/Layer.php
+++ b/src/Model/Canvas/Layer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 final class Layer

--- a/src/Model/Canvas/Layers.php
+++ b/src/Model/Canvas/Layers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 use ArrayIterator;

--- a/src/Model/Canvas/NullShapePainter.php
+++ b/src/Model/Canvas/NullShapePainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 class NullShapePainter implements ShapePainter

--- a/src/Model/Canvas/Painter.php
+++ b/src/Model/Canvas/Painter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 use PhpTui\Tui\Model\Color;
@@ -39,7 +41,7 @@ class Painter
         $x = ($floatPosition->x - $this->context->xBounds->min) * ($this->resolution->width - 1.0) / $width;
         $y = ($this->context->yBounds->max - $floatPosition->y) * ($this->resolution->height - 1.0) / $height;
 
-        return Position::at(intval($x), intval($y));
+        return Position::at((int) $x, (int) $y);
     }
 
     public function paint(Position $position, Color $color): void

--- a/src/Model/Canvas/Resolution.php
+++ b/src/Model/Canvas/Resolution.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 final class Resolution

--- a/src/Model/Canvas/Shape.php
+++ b/src/Model/Canvas/Shape.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 /**

--- a/src/Model/Canvas/ShapePainter.php
+++ b/src/Model/Canvas/ShapePainter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 interface ShapePainter

--- a/src/Model/Canvas/ShapeSet.php
+++ b/src/Model/Canvas/ShapeSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Canvas;
 
 interface ShapeSet

--- a/src/Model/Cell.php
+++ b/src/Model/Cell.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 final class Cell
@@ -38,6 +40,7 @@ final class Cell
     public function setChar(string $char): self
     {
         $this->char = $char;
+
         return $this;
     }
 
@@ -54,6 +57,7 @@ final class Cell
         }
         $this->modifiers |= $style->addModifiers;
         $this->modifiers &= ~$style->subModifiers;
+
         return $this;
     }
 

--- a/src/Model/ClearType.php
+++ b/src/Model/ClearType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 enum ClearType

--- a/src/Model/Color.php
+++ b/src/Model/Color.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 interface Color

--- a/src/Model/Constraint.php
+++ b/src/Model/Constraint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use PhpTui\Tui\Model\Constraint\LengthConstraint;

--- a/src/Model/Constraint/LengthConstraint.php
+++ b/src/Model/Constraint/LengthConstraint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Constraint;
 
 use PhpTui\Tui\Model\Constraint;

--- a/src/Model/Constraint/MaxConstraint.php
+++ b/src/Model/Constraint/MaxConstraint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Constraint;
 
 use PhpTui\Tui\Model\Constraint;

--- a/src/Model/Constraint/MinConstraint.php
+++ b/src/Model/Constraint/MinConstraint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Constraint;
 
 use PhpTui\Tui\Model\Constraint;

--- a/src/Model/Constraint/PercentageConstraint.php
+++ b/src/Model/Constraint/PercentageConstraint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Constraint;
 
 use PhpTui\Tui\Model\Constraint;

--- a/src/Model/ConstraintSolver.php
+++ b/src/Model/ConstraintSolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 interface ConstraintSolver

--- a/src/Model/Corner.php
+++ b/src/Model/Corner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 enum Corner

--- a/src/Model/Direction.php
+++ b/src/Model/Direction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 enum Direction

--- a/src/Model/Display.php
+++ b/src/Model/Display.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use PhpTui\Tui\Model\Viewport\Fullscreen;
@@ -33,6 +35,7 @@ final class Display
         $size = $viewport->size($backend);
         $cursorPos = $viewport->cursorPos($backend);
         $viewportArea = $viewport->area($backend, 0);
+
         return new self(
             $backend,
             [Buffer::empty($viewportArea), Buffer::empty($viewportArea)],

--- a/src/Model/DisplayExtension.php
+++ b/src/Model/DisplayExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use PhpTui\Tui\Model\Canvas\ShapePainter;

--- a/src/Model/Exception/TodoException.php
+++ b/src/Model/Exception/TodoException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Exception;
 
 use RuntimeException;

--- a/src/Model/Layout.php
+++ b/src/Model/Layout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use PhpTui\Tui\Bridge\Cassowary\CassowaryConstraintSolver;
@@ -32,6 +34,7 @@ final class Layout
     public function direction(Direction $direction): self
     {
         $this->direction = $direction;
+
         return $this;
     }
 
@@ -41,6 +44,7 @@ final class Layout
     public function constraints(array $constraints): self
     {
         $this->constraints = $constraints;
+
         return $this;
     }
 

--- a/src/Model/LineComposer.php
+++ b/src/Model/LineComposer.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
+use Generator;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\StyledGrapheme;
-use Generator;
 
 interface LineComposer
 {

--- a/src/Model/LineComposer/LineTruncator.php
+++ b/src/Model/LineComposer/LineTruncator.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\LineComposer;
 
+use Generator;
 use PhpTui\Tui\Model\LineComposer;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\StyledGrapheme;
-use Generator;
 
 class LineTruncator implements LineComposer
 {
@@ -81,6 +83,7 @@ class LineTruncator implements LineComposer
         if ($styledGrapheme->symbolWidth() > $horizontalOffset) {
             $symbol = self::trimOffset($styledGrapheme->symbol, $horizontalOffset);
             $horizontalOffset = 0;
+
             return $symbol;
         }
         $horizontalOffset -= $styledGrapheme->symbolWidth();

--- a/src/Model/Margin.php
+++ b/src/Model/Margin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 class Margin

--- a/src/Model/Marker.php
+++ b/src/Model/Marker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 enum Marker

--- a/src/Model/Modifier.php
+++ b/src/Model/Modifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 final class Modifier

--- a/src/Model/Position.php
+++ b/src/Model/Position.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace PhpTui\Tui\Model;
 
@@ -33,9 +35,10 @@ final class Position implements Stringable
                 $area->__toString()
             ));
         }
+
         return new Position(
             $area->position->x + ($i % $area->width),
-            $area->position->y + intval($i / $area->width),
+            $area->position->y + (int) ($i / $area->width),
         );
     }
 
@@ -55,6 +58,7 @@ final class Position implements Stringable
                 $area->__toString()
             ));
         }
+
         return ($this->y - $area->position->y) * $area->width + ($this->x - $area->position->x);
     }
 

--- a/src/Model/RgbColor.php
+++ b/src/Model/RgbColor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use OutOfBoundsException;
@@ -56,52 +58,59 @@ class RgbColor implements Color
             $lightness = 100;
         } //   0-100
 
-        $dS = $saturation/100.0; // Saturation: 0.0-1.0
-        $dV = $lightness/100.0; // Lightness:  0.0-1.0
-        $dC = $dV*$dS;   // Chroma:     0.0-1.0
-        $dH = $hue/60.0;  // H-Prime:    0.0-6.0
+        $dS = $saturation / 100.0; // Saturation: 0.0-1.0
+        $dV = $lightness / 100.0; // Lightness:  0.0-1.0
+        $dC = $dV * $dS;   // Chroma:     0.0-1.0
+        $dH = $hue / 60.0;  // H-Prime:    0.0-6.0
         $dT = $dH;       // Temp variable
 
         while($dT >= 2.0) {
             $dT -= 2.0;
         } // php modulus does not work with float
-        $dX = $dC*(1-abs($dT-1));     // as used in the Wikipedia link
+        $dX = $dC * (1 - abs($dT - 1));     // as used in the Wikipedia link
 
         switch((int) floor($dH)) {
             case 0:
                 $dR = $dC;
                 $dG = $dX;
                 $dB = 0.0;
+
                 break;
             case 1:
                 $dR = $dX;
                 $dG = $dC;
                 $dB = 0.0;
+
                 break;
             case 2:
                 $dR = 0.0;
                 $dG = $dC;
                 $dB = $dX;
+
                 break;
             case 3:
                 $dR = 0.0;
                 $dG = $dX;
                 $dB = $dC;
+
                 break;
             case 4:
                 $dR = $dX;
                 $dG = 0.0;
                 $dB = $dC;
+
                 break;
             case 5:
                 $dR = $dC;
                 $dG = 0.0;
                 $dB = $dX;
+
                 break;
             default:
                 $dR = 0.0;
                 $dG = 0.0;
                 $dB = 0.0;
+
                 break;
         }
 
@@ -114,9 +123,9 @@ class RgbColor implements Color
         $dB *= 255;
 
         return new self(
-            intval(round($dR)),
-            intval(round($dG)),
-            intval(round($dB))
+            (int) (round($dR)),
+            (int) (round($dG)),
+            (int) (round($dB))
         );
     }
 

--- a/src/Model/Style.php
+++ b/src/Model/Style.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 use Stringable;
@@ -41,18 +43,21 @@ final class Style implements Stringable
     public function fg(Color $color): self
     {
         $this->fg = $color;
+
         return $this;
     }
 
     public function bg(Color $color): self
     {
         $this->bg = $color;
+
         return $this;
     }
 
     public function underline(Color $color): self
     {
         $this->underline = $color;
+
         return $this;
     }
 
@@ -76,6 +81,7 @@ final class Style implements Stringable
     public function addModifier(int $modifier): self
     {
         $this->addModifiers |= $modifier;
+
         return $this;
     }
 
@@ -85,6 +91,7 @@ final class Style implements Stringable
     public function removeModifier(int $modifier): self
     {
         $this->subModifiers |= $modifier;
+
         return $this;
     }
 }

--- a/src/Model/TerminalOptions.php
+++ b/src/Model/TerminalOptions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 final class TerminalOptions

--- a/src/Model/Viewport.php
+++ b/src/Model/Viewport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 interface Viewport

--- a/src/Model/Viewport/Fixed.php
+++ b/src/Model/Viewport/Fixed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Viewport;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Model/Viewport/Fullscreen.php
+++ b/src/Model/Viewport/Fullscreen.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Viewport;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Model/Viewport/Inline.php
+++ b/src/Model/Viewport/Inline.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Viewport;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Model/Widget.php
+++ b/src/Model/Widget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 /**

--- a/src/Model/Widget/BarSet.php
+++ b/src/Model/Widget/BarSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 final class BarSet

--- a/src/Model/Widget/BlockSet.php
+++ b/src/Model/Widget/BlockSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 final class BlockSet

--- a/src/Model/Widget/BorderType.php
+++ b/src/Model/Widget/BorderType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 enum BorderType

--- a/src/Model/Widget/Borders.php
+++ b/src/Model/Widget/Borders.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 final class Borders
 {
-    const NONE   = 0b0000;
-    const TOP    = 0b0001;
-    const RIGHT  = 0b0010;
-    const BOTTOM = 0b0100;
-    const LEFT   = 0b1000;
-    const ALL    = self::TOP | self::RIGHT | self::BOTTOM | self::LEFT;
+    public const NONE   = 0b0000;
+    public const TOP    = 0b0001;
+    public const RIGHT  = 0b0010;
+    public const BOTTOM = 0b0100;
+    public const LEFT   = 0b1000;
+    public const ALL    = self::TOP | self::RIGHT | self::BOTTOM | self::LEFT;
 
     public static function toString(int $borders): string
     {

--- a/src/Model/Widget/BrailleSet.php
+++ b/src/Model/Widget/BrailleSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 final class BrailleSet

--- a/src/Model/Widget/CanvasRenderer.php
+++ b/src/Model/Widget/CanvasRenderer.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Model\Canvas\ShapePainter;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\WidgetRenderer;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
 
 final class CanvasRenderer implements WidgetRenderer
 {
@@ -63,22 +65,22 @@ final class CanvasRenderer implements WidgetRenderer
                 $color = $layer->colors[$index];
                 $x = ($index % $width) + $area->left();
                 $y = ($index / $width) + $area->top();
-                $cell = $buffer->get(Position::at(intval($x), intval($y)))->setChar($char);
+                $cell = $buffer->get(Position::at($x, (int) $y))->setChar($char);
                 $cell->fg = $color->fg;
                 $cell->bg = $color->bg;
             }
         }
 
         foreach ($context->labels->withinBounds($widget->xBounds, $widget->yBounds) as $label) {
-            $x = intval(
+            $x = (int) (
                 ((
                     $label->position->x - $widget->xBounds->min
-                ) * ($area->width -1) / $widget->xBounds->length()) + $area->left()
+                ) * ($area->width - 1) / $widget->xBounds->length()) + $area->left()
             );
-            $y = intval(
+            $y = (int) (
                 ((
                     $widget->yBounds->max - $label->position->y
-                ) * ($area->height -1) / $widget->yBounds->length()) + $area->top()
+                ) * ($area->height - 1) / $widget->yBounds->length()) + $area->top()
             );
             $buffer->putLine(
                 Position::at($x, $y),

--- a/src/Model/Widget/FloatPosition.php
+++ b/src/Model/Widget/FloatPosition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 use Closure;

--- a/src/Model/Widget/HorizontalAlignment.php
+++ b/src/Model/Widget/HorizontalAlignment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 enum HorizontalAlignment

--- a/src/Model/Widget/Line.php
+++ b/src/Model/Widget/Line.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 use ArrayIterator;
-use PhpTui\Tui\Model\Style;
 use IteratorAggregate;
+use PhpTui\Tui\Model\Style;
 use Stringable;
 use Traversable;
 
@@ -65,6 +67,7 @@ final class Line implements IteratorAggregate, Stringable
         foreach ($this->spans as $span) {
             $span->patchStyle($style);
         }
+
         return $this;
     }
 
@@ -74,6 +77,7 @@ final class Line implements IteratorAggregate, Stringable
     public function alignment(HorizontalAlignment $alignment): self
     {
         $this->alignment = $alignment;
+
         return $this;
     }
 

--- a/src/Model/Widget/LineSet.php
+++ b/src/Model/Widget/LineSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 final class LineSet

--- a/src/Model/Widget/Span.php
+++ b/src/Model/Widget/Span.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 use PhpTui\Tui\Model\Style;
@@ -47,6 +49,7 @@ final class Span implements Stringable
     public function style(Style $style): self
     {
         $this->style = $style;
+
         return $this;
     }
 

--- a/src/Model/Widget/StyledGrapheme.php
+++ b/src/Model/Widget/StyledGrapheme.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 use PhpTui\Tui\Model\Style;

--- a/src/Model/Widget/Symbols.php
+++ b/src/Model/Widget/Symbols.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 final class Symbols

--- a/src/Model/Widget/Text.php
+++ b/src/Model/Widget/Text.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 use PhpTui\Tui\Model\Style;
@@ -28,6 +30,7 @@ final class Text
     public static function styled(string $string, Style $style): self
     {
         $text = self::fromString($string);
+
         return $text->patchStyle($style);
     }
 

--- a/src/Model/Widget/Title.php
+++ b/src/Model/Widget/Title.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 final class Title
@@ -19,6 +21,7 @@ final class Title
     public function horizontalAlignmnet(HorizontalAlignment $alignment): self
     {
         $this->horizontalAlignment = $alignment;
+
         return $this;
     }
 
@@ -30,12 +33,14 @@ final class Title
     public function verticalAlignment(VerticalAlignment $alignment): self
     {
         $this->verticalAlignment = $alignment;
+
         return $this;
     }
 
     public function horizontalAlignment(HorizontalAlignment $alignment): self
     {
         $this->horizontalAlignment = $alignment;
+
         return $this;
     }
 }

--- a/src/Model/Widget/VerticalAlignment.php
+++ b/src/Model/Widget/VerticalAlignment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\Widget;
 
 enum VerticalAlignment

--- a/src/Model/WidgetRenderer.php
+++ b/src/Model/WidgetRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 interface WidgetRenderer

--- a/src/Model/WidgetRenderer/AggregateWidgetRenderer.php
+++ b/src/Model/WidgetRenderer/AggregateWidgetRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\WidgetRenderer;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Model/WidgetRenderer/NullWidgetRenderer.php
+++ b/src/Model/WidgetRenderer/NullWidgetRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model\WidgetRenderer;
 
 use PhpTui\Tui\Model\Area;

--- a/src/Model/WidgetSet.php
+++ b/src/Model/WidgetSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Model;
 
 interface WidgetSet

--- a/tests/Benchmark/Extension/Core/Widget/CanvasBench.php
+++ b/tests/Benchmark/Extension/Core/Widget/CanvasBench.php
@@ -1,22 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Benchmark\Extension\Core\Widget;
 
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
-use PhpTui\Term\InformationProvider\ClosureInformationProvider;
 use PhpTui\Term\InformationProvider\AggregateInformationProvider;
-use PhpTui\Term\Terminal;
-use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend;
+use PhpTui\Term\InformationProvider\ClosureInformationProvider;
+use PhpTui\Term\Painter\StringPainter;
 use PhpTui\Term\RawMode\NullRawMode;
 use PhpTui\Term\Size;
-use PhpTui\Term\Painter\StringPainter;
+use PhpTui\Term\Terminal;
+use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend;
 
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Display;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Extension\Core\Shape\Map;
 use PhpTui\Tui\Extension\Core\Shape\MapResolution;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Model\Display;
 
 #[Iterations(10)]
 #[Revs(25)]

--- a/tests/Benchmark/Extension/ImageMagick/ImageShapeBench.php
+++ b/tests/Benchmark/Extension/ImageMagick/ImageShapeBench.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Benchmark\Extension\ImageMagick;
 
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
 use PhpTui\Term\InformationProvider\AggregateInformationProvider;
 use PhpTui\Term\InformationProvider\ClosureInformationProvider;
+use PhpTui\Term\Painter\StringPainter;
 use PhpTui\Term\RawMode\NullRawMode;
 use PhpTui\Term\Size;
-use PhpTui\Term\Painter\StringPainter;
 use PhpTui\Term\Terminal;
-use PhpTui\Tui\Extension\ImageMagick\Shape\ImageShape;
 use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Display;
 use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Extension\ImageMagick\Shape\ImageShape;
+use PhpTui\Tui\Model\Display;
 
 #[Iterations(4)]
 #[Revs(25)]

--- a/tests/Benchmark/Model/DisplayBench.php
+++ b/tests/Benchmark/Model/DisplayBench.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Benchmark\Model;
 
 use PhpBench\Attributes\Iterations;
@@ -12,19 +14,9 @@ use PhpTui\Term\Size;
 use PhpTui\Term\Terminal;
 use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\AxisBounds;
-use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Constraint;
-use PhpTui\Tui\Model\Direction;
-use PhpTui\Tui\Model\Display;
-use PhpTui\Tui\Model\Position;
-use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\Widget\Borders;
-use PhpTui\Tui\Model\Widget\Line;
-use PhpTui\Tui\Model\Widget\Title;
+use PhpTui\Tui\Extension\Core\Shape\Map;
 use PhpTui\Tui\Extension\Core\Widget\Block;
 use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Extension\Core\Shape\Map;
 use PhpTui\Tui\Extension\Core\Widget\Chart;
 use PhpTui\Tui\Extension\Core\Widget\Chart\Axis;
 use PhpTui\Tui\Extension\Core\Widget\Chart\DataSet;
@@ -36,6 +28,16 @@ use PhpTui\Tui\Extension\Core\Widget\RawWidget;
 use PhpTui\Tui\Extension\Core\Widget\Table;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableCell;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableRow;
+use PhpTui\Tui\Model\AxisBounds;
+use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Constraint;
+use PhpTui\Tui\Model\Direction;
+use PhpTui\Tui\Model\Display;
+use PhpTui\Tui\Model\Position;
+use PhpTui\Tui\Model\Widget;
+use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\Line;
+use PhpTui\Tui\Model\Widget\Title;
 
 final class DisplayBench
 {
@@ -104,8 +106,9 @@ final class DisplayBench
         $grid = Grid::default()->direction(Direction::Horizontal);
         $constraints = [];
         foreach ($widgets as $widget) {
-            $constraints[] = Constraint::percentage(intval($width));
+            $constraints[] = Constraint::percentage((int) $width);
         }
+
         return $grid->constraints(...$constraints)->widgets(...$widgets);
     }
 }

--- a/tests/Example/DemoTest.php
+++ b/tests/Example/DemoTest.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Example;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Term\Event;
-use PhpTui\Term\EventProvider\LoadedEventProvider;
 use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\EventProvider\LoadedEventProvider;
 use PhpTui\Term\InformationProvider\AggregateInformationProvider;
 use PhpTui\Term\Painter\BufferPainter;
 use PhpTui\Term\RawMode\NullRawMode;
 use PhpTui\Term\Terminal;
 use PhpTui\Tui\Example\Demo\App;
 use PhpTui\Tui\Model\Backend\DummyBackend;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class DemoTest extends TestCase
@@ -119,6 +121,7 @@ class DemoTest extends TestCase
             $backend,
         );
         $app->run();
+
         return $backend;
     }
 

--- a/tests/Example/DocsTest.php
+++ b/tests/Example/DocsTest.php
@@ -1,18 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Example;
 
 use Generator;
-use PHPUnit\Framework\TestCase;
 use PhpTui\Term\AnsiParser;
 use PhpTui\Term\Painter\HtmlCanvasPainter;
 use PhpTui\Term\Painter\StringPainter;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class DocsTest extends TestCase
 {
-    const WIDTH = 20;
-    const HEIGHT = 50;
+    public const WIDTH = 20;
+    public const HEIGHT = 50;
 
     /**
      * @dataProvider provideExamples
@@ -82,6 +84,7 @@ class DocsTest extends TestCase
         }
         if (!file_exists($snapshot) || getenv('SNAPSHOT_APPROVE')) {
             file_put_contents($snapshot, $output);
+
             return;
         }
 
@@ -98,6 +101,7 @@ class DocsTest extends TestCase
     {
         $normalized = preg_replace('{canvas id=".*?"}', 'canvas id="***"', $string);
         $normalized = preg_replace('{getElementById\(".*?"\)}', 'getElementById("***")', (string)$normalized);
+
         return (string)$normalized;
     }
 }

--- a/tests/Unit/Bridge/Cassowary/CassowaryConstraintSolverTest.php
+++ b/tests/Unit/Bridge/Cassowary/CassowaryConstraintSolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Bridge\Cassowary;
 
 use PhpTui\Tui\Model\Area;

--- a/tests/Unit/Bridge/PhpTerm/PhpTermBackendTest.php
+++ b/tests/Unit/Bridge/PhpTerm/PhpTermBackendTest.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Bridge\PhpTerm;
 
-use PhpTui\Term\Painter\BufferPainter;
 use PhpTui\Term\Action;
+use PhpTui\Term\Painter\BufferPainter;
 use PhpTui\Term\Terminal;
 use PhpTui\Tui\Bridge\PhpTerm\PhpTermBackend;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\BufferUpdate;
+use PhpTui\Tui\Model\BufferUpdates;
+use PhpTui\Tui\Model\Cell;
 use PhpTui\Tui\Model\Modifier;
+use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\RgbColor;
 use PhpTui\Tui\Model\Style;
-use PhpTui\Tui\Model\Cell;
-use PhpTui\Tui\Model\Position;
-use PhpTui\Tui\Model\BufferUpdates;
 use PHPUnit\Framework\TestCase;
 
 class PhpTermBackendTest extends TestCase

--- a/tests/Unit/DisplayBuilderTest.php
+++ b/tests/Unit/DisplayBuilderTest.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\DisplayBuilder;
-use PhpTui\Tui\Model\Backend\DummyBackend;
-use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Area;
-use PhpTui\Tui\Model\DisplayExtension;
-use PhpTui\Tui\Model\Widget;
-use PhpTui\Tui\Model\WidgetRenderer;
 use PhpTui\Tui\Extension\Core\Shape\ClosurePainter;
 use PhpTui\Tui\Extension\Core\Shape\ClosureShape;
 use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Extension\Core\Widget\ClosureRenderer;
+use PhpTui\Tui\Model\Area;
+use PhpTui\Tui\Model\Backend\DummyBackend;
+use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\DisplayExtension;
+use PhpTui\Tui\Model\Widget;
+use PhpTui\Tui\Model\WidgetRenderer;
+use PHPUnit\Framework\TestCase;
 
 final class DisplayBuilderTest extends TestCase
 {

--- a/tests/Unit/Extension/Bdf/Shape/TextShapeTest.php
+++ b/tests/Unit/Extension/Bdf/Shape/TextShapeTest.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Bdf\Shape;
 
+use Generator;
 use PhpTui\Tui\Extension\Bdf\FontRegistry;
 use PhpTui\Tui\Extension\Bdf\Shape\TextRenderer;
 use PhpTui\Tui\Extension\Bdf\Shape\TextShape;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Model\WidgetRenderer\NullWidgetRenderer;
-use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Widget\CanvasRenderer;
 use PhpTui\Tui\Model\Canvas\CanvasContext;
-use Generator;
+use PhpTui\Tui\Model\Marker;
+use PhpTui\Tui\Model\Widget\CanvasRenderer;
+use PhpTui\Tui\Model\Widget\FloatPosition;
+use PhpTui\Tui\Model\WidgetRenderer\NullWidgetRenderer;
 use PHPUnit\Framework\TestCase;
 
 class TextShapeTest extends TestCase

--- a/tests/Unit/Extension/Core/Shape/CircleTest.php
+++ b/tests/Unit/Extension/Core/Shape/CircleTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Shape;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Shape\Circle;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Shape\Circle;
-use Generator;
+use PhpTui\Tui\Model\Marker;
 
 class CircleTest extends ShapeTestCase
 {

--- a/tests/Unit/Extension/Core/Shape/LineTest.php
+++ b/tests/Unit/Extension/Core/Shape/LineTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Shape;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Shape\Line;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Shape\Line;
-use Generator;
+use PhpTui\Tui\Model\Marker;
 
 class LineTest extends ShapeTestCase
 {

--- a/tests/Unit/Extension/Core/Shape/MapTest.php
+++ b/tests/Unit/Extension/Core/Shape/MapTest.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Shape;
 
-use PhpTui\Tui\Model\AxisBounds;
-use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Area;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
+use Generator;
 use PhpTui\Tui\Extension\Core\Shape\Map;
 use PhpTui\Tui\Extension\Core\Shape\MapResolution;
-use Generator;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Model\Area;
+use PhpTui\Tui\Model\AxisBounds;
+use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
+use PhpTui\Tui\Model\Marker;
 
 class MapTest extends ShapeTestCase
 {

--- a/tests/Unit/Extension/Core/Shape/PointsTest.php
+++ b/tests/Unit/Extension/Core/Shape/PointsTest.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Shape;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Shape\Points;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Shape\Points;
-use Generator;
+use PhpTui\Tui\Model\Marker;
 
 class PointsTest extends ShapeTestCase
 {

--- a/tests/Unit/Extension/Core/Shape/RectangleTest.php
+++ b/tests/Unit/Extension/Core/Shape/RectangleTest.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Shape;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Shape\Rectangle;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Shape\Rectangle;
-use Generator;
+use PhpTui\Tui\Model\Marker;
 
 class RectangleTest extends ShapeTestCase
 {

--- a/tests/Unit/Extension/Core/Shape/ShapeTestCase.php
+++ b/tests/Unit/Extension/Core/Shape/ShapeTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Shape;
 
 use PhpTui\Tui\Tests\Unit\Extension\Core\Widget\WidgetTestCase;

--- a/tests/Unit/Extension/Core/Shape/SpriteTest.php
+++ b/tests/Unit/Extension/Core/Shape/SpriteTest.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Shape;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Shape\Sprite;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
-use Generator;
-use PhpTui\Tui\Extension\Core\Shape\Sprite;
 
 class SpriteTest extends ShapeTestCase
 {

--- a/tests/Unit/Extension/Core/Widget/Block/PaddingTest.php
+++ b/tests/Unit/Extension/Core/Widget/Block/PaddingTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget\Block;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
+use PHPUnit\Framework\TestCase;
 
 class PaddingTest extends TestCase
 {

--- a/tests/Unit/Extension/Core/Widget/BlockTest.php
+++ b/tests/Unit/Extension/Core/Widget/BlockTest.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
 use Closure;
+use Generator;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph;
+use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Widget\BorderType;
 use PhpTui\Tui\Model\Widget\Borders;
+use PhpTui\Tui\Model\Widget\BorderType;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\Text;
 use PhpTui\Tui\Model\Widget\Title;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Model\Area;
-use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph;
-use Generator;
 
 class BlockTest extends WidgetTestCase
 {

--- a/tests/Unit/Extension/Core/Widget/Canvas/Grid/BrailleGridTest.php
+++ b/tests/Unit/Extension/Core/Widget/Canvas/Grid/BrailleGridTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget\Canvas\Grid;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Canvas\Grid\BrailleGrid;
+use PhpTui\Tui\Model\Position;
+use PHPUnit\Framework\TestCase;
 
 class BrailleGridTest extends TestCase
 {

--- a/tests/Unit/Extension/Core/Widget/Canvas/Grid/CharGridTest.php
+++ b/tests/Unit/Extension/Core/Widget/Canvas/Grid/CharGridTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget\Canvas\Grid;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Canvas\Grid\CharGrid;
+use PhpTui\Tui\Model\Position;
+use PHPUnit\Framework\TestCase;
 
 class CharGridTest extends TestCase
 {

--- a/tests/Unit/Extension/Core/Widget/Canvas/Grid/HalfBlockGridTest.php
+++ b/tests/Unit/Extension/Core/Widget/Canvas/Grid/HalfBlockGridTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget\Canvas\Grid;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Model\AnsiColor;
-use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Canvas\Grid\HalfBlockGrid;
+use PhpTui\Tui\Model\Position;
+use PHPUnit\Framework\TestCase;
 
 class HalfBlockGridTest extends TestCase
 {

--- a/tests/Unit/Extension/Core/Widget/CanvasTest.php
+++ b/tests/Unit/Extension/Core/Widget/CanvasTest.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Shape\Circle;
+use PhpTui\Tui\Extension\Core\Shape\Line;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Canvas\CanvasContext;
 use PhpTui\Tui\Model\Cell;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Widget\Line as DTLLine;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Canvas\CanvasContext;
-use PhpTui\Tui\Extension\Core\Shape\Circle;
-use PhpTui\Tui\Extension\Core\Shape\Line;
-use Generator;
 
 class CanvasTest extends WidgetTestCase
 {

--- a/tests/Unit/Extension/Core/Widget/ChartTest.php
+++ b/tests/Unit/Extension/Core/Widget/ChartTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
+use PhpTui\Tui\Extension\Core\Widget\Chart;
+use PhpTui\Tui\Extension\Core\Widget\Chart\Axis;
+use PhpTui\Tui\Extension\Core\Widget\Chart\DataSet;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget\Span;
-use PhpTui\Tui\Extension\Core\Widget\Chart;
-use PhpTui\Tui\Extension\Core\Widget\Chart\Axis;
-use PhpTui\Tui\Extension\Core\Widget\Chart\DataSet;
 
 class ChartTest extends WidgetTestCase
 {

--- a/tests/Unit/Extension/Core/Widget/GridTest.php
+++ b/tests/Unit/Extension/Core/Widget/GridTest.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Grid;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Constraint;
 use PhpTui\Tui\Model\Direction;
 use PhpTui\Tui\Model\Widget\Borders;
 use PhpTui\Tui\Model\Widget\Text;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Grid;
-use Generator;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 use RuntimeException;
 
 class GridTest extends WidgetTestCase

--- a/tests/Unit/Extension/Core/Widget/ItemListTest.php
+++ b/tests/Unit/Extension/Core/Widget/ItemListTest.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Widget\ItemList;
+use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Corner;
 use PhpTui\Tui\Model\Widget\Text;
-use PhpTui\Tui\Extension\Core\Widget\ItemList;
-use PhpTui\Tui\Extension\Core\Widget\ItemList\ListItem;
-use Generator;
 
 class ItemListTest extends WidgetTestCase
 {

--- a/tests/Unit/Extension/Core/Widget/ParagraphTest.php
+++ b/tests/Unit/Extension/Core/Widget/ParagraphTest.php
@@ -1,18 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Widget\HorizontalAlignment;
 use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Text;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph;
-use Generator;
 
 class ParagraphTest extends WidgetTestCase
 {
-
     public function testFromString(): void
     {
         $paragraph = Paragraph::fromString('Hello');

--- a/tests/Unit/Extension/Core/Widget/RawWidgetTest.php
+++ b/tests/Unit/Extension/Core/Widget/RawWidgetTest.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Widget\Block;
+use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
+use PhpTui\Tui\Extension\Core\Widget\RawWidget;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\Widget\Line;
 use PhpTui\Tui\Model\Widget\Span;
-use PhpTui\Tui\Extension\Core\Widget\Block;
-use PhpTui\Tui\Extension\Core\Widget\Block\Padding;
-use PhpTui\Tui\Extension\Core\Widget\RawWidget;
-use Generator;
 
 class RawWidgetTest extends WidgetTestCase
 {

--- a/tests/Unit/Extension/Core/Widget/TableTest.php
+++ b/tests/Unit/Extension/Core/Widget/TableTest.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
-use PhpTui\Tui\Model\Area;
-use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Constraint;
+use Generator;
 use PhpTui\Tui\Extension\Core\Widget\Table;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableCell;
 use PhpTui\Tui\Extension\Core\Widget\Table\TableRow;
-use Generator;
+use PhpTui\Tui\Model\Area;
+use PhpTui\Tui\Model\Buffer;
+use PhpTui\Tui\Model\Constraint;
 
 class TableTest extends WidgetTestCase
 {

--- a/tests/Unit/Extension/Core/Widget/WidgetTestCase.php
+++ b/tests/Unit/Extension/Core/Widget/WidgetTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 
-use PHPUnit\Framework\TestCase;
+use PhpTui\Tui\Extension\Core\Shape\DefaultShapeSet;
+use PhpTui\Tui\Extension\Core\Widget\DefaultWidgetSet;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Canvas\AggregateShapePainter;
@@ -10,12 +13,10 @@ use PhpTui\Tui\Model\Widget;
 use PhpTui\Tui\Model\WidgetRenderer;
 use PhpTui\Tui\Model\WidgetRenderer\AggregateWidgetRenderer;
 use PhpTui\Tui\Model\WidgetRenderer\NullWidgetRenderer;
-use PhpTui\Tui\Extension\Core\Shape\DefaultShapeSet;
-use PhpTui\Tui\Extension\Core\Widget\DefaultWidgetSet;
+use PHPUnit\Framework\TestCase;
 
 class WidgetTestCase extends TestCase
 {
-
     protected function render(Buffer $buffer, Widget $widget): void
     {
         $this->renderer()->render(
@@ -34,6 +35,7 @@ class WidgetTestCase extends TestCase
         $area = Area::fromDimensions($width, $height);
         $buffer = Buffer::empty($area);
         $this->renderer()->render(new NullWidgetRenderer(), $widget, $area, $buffer);
+
         return $buffer->toLines();
     }
     private function renderer(): WidgetRenderer

--- a/tests/Unit/Extension/ImageMagick/Shape/ImageShapeTest.php
+++ b/tests/Unit/Extension/ImageMagick/Shape/ImageShapeTest.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\ImageMagick\Shape;
 
+use Generator;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
 use PhpTui\Tui\Extension\ImageMagick\Shape\ImagePainter;
 use PhpTui\Tui\Extension\ImageMagick\Shape\ImageShape;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\AxisBounds;
 use PhpTui\Tui\Model\Buffer;
-use PhpTui\Tui\Model\Marker;
-use PhpTui\Tui\Model\WidgetRenderer\NullWidgetRenderer;
-use PhpTui\Tui\Model\Widget\FloatPosition;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Model\Widget\CanvasRenderer;
 use PhpTui\Tui\Model\Canvas\CanvasContext;
-use Generator;
+use PhpTui\Tui\Model\Marker;
+use PhpTui\Tui\Model\Widget\CanvasRenderer;
+use PhpTui\Tui\Model\Widget\FloatPosition;
+use PhpTui\Tui\Model\WidgetRenderer\NullWidgetRenderer;
 use PHPUnit\Framework\TestCase;
 
 class ImageShapeTest extends TestCase
@@ -53,6 +55,7 @@ class ImageShapeTest extends TestCase
                 Marker::Block,
                 [''],
             ];
+
             return;
         }
         yield 'renders image (no colors in this test!)' => [

--- a/tests/Unit/Extension/ImageMagick/Widget/ImageRendererTest.php
+++ b/tests/Unit/Extension/ImageMagick/Widget/ImageRendererTest.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Extension\ImageMagick\Widget;
 
 use PhpTui\Tui\DisplayBuilder;
 use PhpTui\Tui\Extension\ImageMagick\ImageMagickExtension;
 use PhpTui\Tui\Extension\ImageMagick\Widget\ImageWidget;
 use PhpTui\Tui\Model\Backend\DummyBackend;
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Model\Marker;
+use PHPUnit\Framework\TestCase;
 
 class ImageRendererTest extends TestCase
 {

--- a/tests/Unit/Model/AnsiColorTest.php
+++ b/tests/Unit/Model/AnsiColorTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Model\AnsiColor;
+use PHPUnit\Framework\TestCase;
 use ValueError;
 
 class AnsiColorTest extends TestCase

--- a/tests/Unit/Model/AreaTest.php
+++ b/tests/Unit/Model/AreaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
 use PhpTui\Tui\Model\Area;

--- a/tests/Unit/Model/BufferTest.php
+++ b/tests/Unit/Model/BufferTest.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
 use Closure;
+use Generator;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Buffer;
@@ -12,7 +15,6 @@ use PhpTui\Tui\Model\Position;
 use PhpTui\Tui\Model\RgbColor;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Widget\Line;
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 class BufferTest extends TestCase

--- a/tests/Unit/Model/DisplayTest.php
+++ b/tests/Unit/Model/DisplayTest.php
@@ -1,18 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
 use PhpTui\Tui\DisplayBuilder;
+use PhpTui\Tui\Extension\Core\Shape\Points;
+use PhpTui\Tui\Extension\Core\Widget\Canvas;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph;
+use PhpTui\Tui\Extension\Core\Widget\RawWidget;
 use PhpTui\Tui\Model\AnsiColor;
 use PhpTui\Tui\Model\Backend\DummyBackend;
 use PhpTui\Tui\Model\Buffer;
 use PhpTui\Tui\Model\Marker;
 use PhpTui\Tui\Model\Position;
 use PHPUnit\Framework\TestCase;
-use PhpTui\Tui\Extension\Core\Widget\Canvas;
-use PhpTui\Tui\Extension\Core\Shape\Points;
-use PhpTui\Tui\Extension\Core\Widget\Paragraph;
-use PhpTui\Tui\Extension\Core\Widget\RawWidget;
 
 class DisplayTest extends TestCase
 {

--- a/tests/Unit/Model/LayoutTest.php
+++ b/tests/Unit/Model/LayoutTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
 use PhpTui\Tui\Model\Area;

--- a/tests/Unit/Model/PositionTest.php
+++ b/tests/Unit/Model/PositionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
 use PhpTui\Tui\Model\Area;

--- a/tests/Unit/Model/RgbColorTest.php
+++ b/tests/Unit/Model/RgbColorTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
-use PHPUnit\Framework\TestCase;
 use PhpTui\Tui\Model\RgbColor;
+use PHPUnit\Framework\TestCase;
 
 class RgbColorTest extends TestCase
 {

--- a/tests/Unit/Model/StyleTest.php
+++ b/tests/Unit/Model/StyleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model;
 
 use PhpTui\Tui\Model\AnsiColor;

--- a/tests/Unit/Model/Widget/FloatPositionTest.php
+++ b/tests/Unit/Model/Widget/FloatPositionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model\Widget;
 
 use PhpTui\Tui\Model\AxisBounds;

--- a/tests/Unit/Model/Widget/TextTest.php
+++ b/tests/Unit/Model/Widget/TextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpTui\Tui\Tests\Unit\Model\Widget;
 
 use PhpTui\Tui\Model\AnsiColor;


### PR DESCRIPTION
I noticed that `blank_line_before_statement` is used in PHP Bench, but I'm not sure if you want to use it here. Just let me know.

Changes:

- `declare_strict_types` -> Will add all missing `declare(strict_types=1);`
- `modernize_types_casting` -> will change all `intval()` function call to `(int)`
- `ordered_imports` -> will order imports in a saner way
- `blank_line_before_statement` -> will add blank lines before statements like return etc

I didn't run the `php-cs-fixer` on this PR because it would change dozens of files and make your life harder. If you approve these changes, you can run the cs-fixer whenever it's more convenient for you.

If you don´t approve this kind of change, you can feel free to close. :heart: 