### PR TITLE
Chore: some minor improvements to `Cell`

### DIFF
--- a/src/Model/Buffer.php
+++ b/src/Model/Buffer.php
@@ -39,7 +39,7 @@ final class Buffer implements Countable
     {
         $content = [];
         for ($i = 0; $i < $area->area(); $i++) {
-            $content[] = $cell->clone();
+            $content[] = clone $cell;
         }
 
         return new self($area, $content);

--- a/src/Model/Cell.php
+++ b/src/Model/Cell.php
@@ -27,14 +27,14 @@ final class Cell
         );
     }
 
-    public static function empty(): self
-    {
-        return new self(' ', AnsiColor::Reset, AnsiColor::Reset, AnsiColor::Reset, Modifier::NONE);
-    }
-
     public static function fromChar(string $char): self
     {
         return new self($char, AnsiColor::Reset, AnsiColor::Reset, AnsiColor::Reset, Modifier::NONE);
+    }
+
+    public static function empty(): self
+    {
+        return self::fromChar(' ');
     }
 
     public function setChar(string $char): self
@@ -64,22 +64,10 @@ final class Cell
     public function equals(Cell $currentCell): bool
     {
         return
-            $this->underline == $currentCell->underline &&
-            $this->modifiers === $currentCell->modifiers &&
+            $this->char === $currentCell->char &&
             $this->fg == $currentCell->fg &&
             $this->bg == $currentCell->bg &&
-            $this->char === $currentCell->char
-        ;
-    }
-
-    public function clone(): self
-    {
-        return new self(
-            char: $this->char,
-            fg: $this->fg,
-            bg: $this->bg,
-            underline: $this->underline,
-            modifiers: $this->modifiers,
-        );
+            $this->modifiers === $currentCell->modifiers &&
+            $this->underline == $currentCell->underline;
     }
 }


### PR DESCRIPTION
Changes:

- Since a `Color` is immutable, we don't need to deep clone `Cell`, we can simply use the `clone` operator. 
- I've changed the order of evaluation in `equals` (not a big deal, though)

I've seen no performance regression; on the contrary, it has improved.

```
Suites
+-----------+---------------------+--------+------------+--------+------------+------+----------+----------+
| suite     | date                | php    | vcs branch | xdebug | iterations | revs | mode     | net_time |
+-----------+---------------------+--------+------------+--------+------------+------+----------+----------+
| <current> | 2023-11-15 16:45:48 | 8.2.12 | cell       | false  | 44         | 1100 | 12.525ms | 11.963s  |
| main      | 2023-11-15 16:24:08 | 8.2.12 | main       | false  | 44         | 1100 | 14.750ms | 13.628s  |
+-----------+---------------------+--------+------------+--------+------------+------+----------+----------+
```

```
<current>
+-----------------+---------------------------+---------+----------+----------+----------+--------+-----------+
| benchmark       | subject                   | memory  | min      | max      | mode     | rstdev | stdev     |
+-----------------+---------------------------+---------+----------+----------+----------+--------+-----------+
| DisplayBench    | benchRenderFrame ()       | 7.967mb | 9.743ms  | 10.150ms | 9.880ms  | ±1.10% | 108.574μs |
| ImageShapeBench | benchImageShape ()        | 8.110mb | 11.838ms | 12.218ms | 11.929ms | ±1.21% | 144.852μs |
| CanvasBench     | benchLowResolutionMap ()  | 8.311mb | 13.455ms | 13.807ms | 13.516ms | ±0.90% | 122.274μs |
| CanvasBench     | benchHighResolutionMap () | 8.311mb | 17.128ms | 18.090ms | 17.292ms | ±1.61% | 279.771μs |
| BdfParserBench  | benchParseRealFont ()     | 5.060mb | 2.113ms  | 2.160ms  | 2.131ms  | ±0.62% | 13.267μs  |
+-----------------+---------------------------+---------+----------+----------+----------+--------+-----------+

main
+-----------------+---------------------------+---------+----------+----------+----------+--------+-----------+
| benchmark       | subject                   | memory  | min      | max      | mode     | rstdev | stdev     |
+-----------------+---------------------------+---------+----------+----------+----------+--------+-----------+
| DisplayBench    | benchRenderFrame ()       | 7.967mb | 11.824ms | 12.297ms | 11.916ms | ±1.46% | 175.753μs |
| ImageShapeBench | benchImageShape ()        | 8.110mb | 13.861ms | 14.127ms | 13.896ms | ±0.88% | 122.463μs |
| CanvasBench     | benchLowResolutionMap ()  | 8.311mb | 15.319ms | 15.748ms | 15.410ms | ±0.93% | 143.396μs |
| CanvasBench     | benchHighResolutionMap () | 8.311mb | 19.054ms | 19.625ms | 19.153ms | ±1.02% | 197.414μs |
| BdfParserBench  | benchParseRealFont ()     | 5.060mb | 2.082ms  | 2.162ms  | 2.123ms  | ±1.00% | 21.266μs  |
+-----------------+---------------------------+---------+----------+----------+----------+--------+-----------+
```