### PR TITLE
Conditionally retain the style of a `Span`

### DIFF
--- a/src/Model/Widget/Line.php
+++ b/src/Model/Widget/Line.php
@@ -69,6 +69,10 @@ final class Line implements IteratorAggregate, Stringable, Styleable
     public function patchStyle(Style $style): self
     {
         foreach ($this->spans as $span) {
+            if ($span->retainStyle) {
+                continue;
+            }
+
             $span->patchStyle($style);
         }
 

--- a/src/Model/Widget/Span.php
+++ b/src/Model/Widget/Span.php
@@ -13,8 +13,11 @@ final class Span implements Stringable, Styleable
 {
     use StyleableTrait;
 
-    public function __construct(public readonly string $content, public Style $style)
-    {
+    public function __construct(
+        public readonly string $content,
+        public Style $style,
+        public bool $retainStyle,
+    ) {
     }
 
     public function __toString(): string
@@ -24,7 +27,7 @@ final class Span implements Stringable, Styleable
 
     public static function fromString(string $string): self
     {
-        return new self($string, Style::default());
+        return new self($string, Style::default(), false);
     }
 
     public function width(): int
@@ -59,8 +62,15 @@ final class Span implements Stringable, Styleable
         return $this;
     }
 
+    public function retainStyle(): self
+    {
+        $this->retainStyle = true;
+
+        return $this;
+    }
+
     public static function styled(string $string, Style $style): self
     {
-        return new self($string, $style);
+        return new self($string, $style, false);
     }
 }


### PR DESCRIPTION
Currently, we have:

```php
Line::fromSpans([
    Span::fromString('H')->red(),
    Span::fromString('e'),
    Span::fromString('l'),
    Span::fromString('l'),
    Span::fromString('o'),
])->green(),
```

When `green()` is applied to the line, it overrides the styles of all spans.

What if we introduce a new method `retainStyle()` for the `Span` to prevent this?

Not sure about the name tho: `retainStyle()`, `keepStyle()`, `forceStyle()`, `dontPathStyle()`

The code would then be updated to:

```php
Line::fromSpans([
    Span::fromString('H')->retainStyle()->red(),
    Span::fromString('e'),
    Span::fromString('l'),
    Span::fromString('l'),
    Span::fromString('o'),
])->green(),
```

With this change, `H` will retain its red color, while the rest of the characters will be green.

Does this makes any sense or I am overthinking? :sweat_smile: Maybe we don't need to worry about this for now...

