### PR TITLE
Chore: integrates Rector into our pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-phpunit": "^1.0",
+        "rector/rector": "^0.18.10"
     },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan --memory-limit=1G",
@@ -47,7 +48,9 @@
         "phpunit": "./vendor/bin/phpunit",
         "docs": "php ./scripts/docgen",
         "phpbench": "php ./vendor/bin/phpbench run --revs=1 --iterations=1",
+        "rector": "./vendor/bin/rector process",
         "integrate": [
+            "@rector",
             "@php-cs-fixer",
             "@phpstan",
             "@phpunit",

--- a/lib/bdf/src/BdfParser.php
+++ b/lib/bdf/src/BdfParser.php
@@ -82,13 +82,7 @@ final class BdfParser
      */
     private function notNull(mixed ...$values): bool
     {
-        foreach ($values as $value) {
-            if ($value === null) {
-                return false;
-            }
-        }
-
-        return true;
+        return !in_array(null, $values, true);
     }
 
     private function parseProperties(BdfTokenStream $tokens): BdfProperties

--- a/lib/bdf/src/BdfResult.php
+++ b/lib/bdf/src/BdfResult.php
@@ -41,6 +41,6 @@ final class BdfResult
 
     public function isOk(): bool
     {
-        return $this->ok === true;
+        return $this->ok;
     }
 }

--- a/lib/bdf/tests/Benchmark/BdfParserBench.php
+++ b/lib/bdf/tests/Benchmark/BdfParserBench.php
@@ -13,7 +13,7 @@ use RuntimeException;
 #[Revs(25)]
 final class BdfParserBench
 {
-    private string $contents;
+    private readonly string $contents;
 
     public function __construct()
     {

--- a/lib/docgen/src/Docgen.php
+++ b/lib/docgen/src/Docgen.php
@@ -161,9 +161,8 @@ final class Docgen
         if (null === $docblock) {
             return null;
         }
-        $node = $this->parser->parse(new TokenIterator($this->lexer->tokenize($docblock)));
 
-        return $node;
+        return $this->parser->parse(new TokenIterator($this->lexer->tokenize($docblock)));
     }
 
     private function description(?PhpDocNode $node): ?string

--- a/lib/docgen/src/Docgen.php
+++ b/lib/docgen/src/Docgen.php
@@ -34,10 +34,10 @@ final class Docgen
      * @param iterable<int,ReflectionClass> $classes
      */
     private function __construct(
-        private string $docsDir,
-        private iterable $classes,
-        private Lexer $lexer,
-        private PhpDocParser $parser,
+        private readonly string $docsDir,
+        private readonly iterable $classes,
+        private readonly Lexer $lexer,
+        private readonly PhpDocParser $parser,
     ) {
     }
     public function generate(): void
@@ -58,7 +58,7 @@ final class Docgen
             $docsDir,
             $reflector->reflectAllClasses(),
             new Lexer(),
-            (function () {
+            (function (): PhpDocParser {
                 $constExpr = new ConstExprParser();
 
                 return new PhpDocParser(new TypeParser($constExpr), $constExpr);
@@ -89,7 +89,7 @@ final class Docgen
                         $type = implode(
                             '|',
                             array_map(
-                                fn (VarTagValueNode $node) => $node->__toString(),
+                                static fn (VarTagValueNode $node): string => $node->__toString(),
                                 $phpDoc->getVarTagValues()
                             )
                         );
@@ -129,7 +129,7 @@ final class Docgen
                         $type = implode(
                             '|',
                             array_map(
-                                fn (VarTagValueNode $node) => $node->__toString(),
+                                static fn (VarTagValueNode $node): string => $node->__toString(),
                                 $phpDoc->getVarTagValues()
                             )
                         );

--- a/lib/term/src/Action/RequestCursorPosition.php
+++ b/lib/term/src/Action/RequestCursorPosition.php
@@ -14,6 +14,6 @@ final class RequestCursorPosition implements Action
 {
     public function __toString(): string
     {
-        return sprintf('RequestCursorPosition()');
+        return 'RequestCursorPosition()';
     }
 }

--- a/lib/term/src/AnsiParser.php
+++ b/lib/term/src/AnsiParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpTui\Term;
 
+use PhpTui\Term\Action\AlternateScreenEnable;
 use PhpTui\Term\Action\PrintString;
 
 /**
@@ -24,7 +25,7 @@ final class AnsiParser
      */
     private array $actions = [];
 
-    public function __construct(private bool $throw = false)
+    public function __construct(private readonly bool $throw = false)
     {
     }
 
@@ -47,7 +48,7 @@ final class AnsiParser
             }
             if ($strings) {
                 $newActions[] = Actions::printString(
-                    implode('', array_map(fn (PrintString $s) => $s->string, $strings))
+                    implode('', array_map(static fn (PrintString $s): string => $s->string, $strings))
                 );
                 $strings = [];
             }
@@ -55,7 +56,7 @@ final class AnsiParser
         }
         if ($strings) {
             $newActions[] = Actions::printString(
-                implode('', array_map(fn (PrintString $s) => $s->string, $strings))
+                implode('', array_map(static fn (PrintString $s): string => $s->string, $strings))
             );
         }
 
@@ -181,7 +182,7 @@ final class AnsiParser
 
         // true colors
         if (count($parts) === 5) {
-            $rgb = array_map(fn (string $index) => (int) $index, array_slice($parts, -3));
+            $rgb = array_map(static fn (string $index): int => (int) $index, array_slice($parts, -3));
 
             return match ($parts[0]) {
                 '48' => Actions::setRgbBackgroundColor(...$rgb),
@@ -235,7 +236,7 @@ final class AnsiParser
                 default => throw ParseError::couldNotParseBuffer($buffer),
             },
             '0' => match ($buffer[5]) {
-                '4' => (function () use ($buffer) {
+                '4' => (function () use ($buffer): ?AlternateScreenEnable {
                     if (count($buffer) === 6 || count($buffer) === 7) {
                         return null;
                     }

--- a/lib/term/src/EventParser.php
+++ b/lib/term/src/EventParser.php
@@ -187,7 +187,7 @@ final class EventParser
         $str = implode('', array_slice($buffer, 2, (int)array_key_last($buffer)));
 
         $split = array_map(
-            static fn (string $substr): int => self::filterToInt($substr) ?? 0,
+            fn (string $substr): int => $this->filterToInt($substr) ?? 0,
             explode(';', $str),
         );
         $first = $split[array_key_first($split)];
@@ -304,12 +304,12 @@ final class EventParser
             throw new ParseError('Could not parse modifier');
         }
         $parts = explode(':', $parts[1]);
-        $modifierMask = self::filterToInt($parts[0]);
+        $modifierMask = $this->filterToInt($parts[0]);
         if (null === $modifierMask) {
             return null;
         }
         if (isset($parts[1])) {
-            $kindCode = self::filterToInt($parts[1]);
+            $kindCode = $this->filterToInt($parts[1]);
             if (null === $kindCode) {
                 return null;
             }
@@ -320,7 +320,7 @@ final class EventParser
         return [$modifierMask, 1];
     }
 
-    private static function filterToInt(string $substr): ?int
+    private function filterToInt(string $substr): ?int
     {
         $str = array_reduce(
             str_split($substr),

--- a/lib/term/src/EventParser.php
+++ b/lib/term/src/EventParser.php
@@ -46,7 +46,7 @@ final class EventParser
 
             try {
                 $event = $this->parseEvent($this->buffer, $more);
-            } catch (ParseError $error) {
+            } catch (ParseError) {
                 $this->buffer = [];
 
                 continue;
@@ -99,7 +99,7 @@ final class EventParser
         return match ($buffer[1]) {
             '[' => $this->parseCsi($buffer),
             "\x1B" => CodedKeyEvent::new(KeyCode::Esc),
-            'O' => (function () use ($buffer) {
+            'O' => (function () use ($buffer): null|FunctionKeyEvent|CodedKeyEvent {
                 if (count($buffer) === 2) {
                     return null;
                 }
@@ -187,7 +187,7 @@ final class EventParser
         $str = implode('', array_slice($buffer, 2, (int)array_key_last($buffer)));
 
         $split = array_map(
-            fn (string $substr) => self::filterToInt($substr) ?? 0,
+            static fn (string $substr): int => self::filterToInt($substr) ?? 0,
             explode(';', $str),
         );
         $first = $split[array_key_first($split)];
@@ -253,7 +253,7 @@ final class EventParser
         // split string into bytes
         $parts = explode(';', $str);
 
-        [$modifiers, $kind] = (function () use ($parts) {
+        [$modifiers, $kind] = (function () use ($parts): array {
             $modifierAndKindCode  = $this->modifierAndKindParsed($parts);
             if (null !== $modifierAndKindCode) {
                 return [
@@ -324,7 +324,7 @@ final class EventParser
     {
         $str = array_reduce(
             str_split($substr),
-            function (string $ac, string $char) {
+            function (string $ac, string $char): string {
                 if (false === is_numeric($char)) {
                     return $ac;
                 }

--- a/lib/term/src/EventProvider/SyncEventProvider.php
+++ b/lib/term/src/EventProvider/SyncEventProvider.php
@@ -17,7 +17,7 @@ final class SyncEventProvider implements EventProvider
      */
     private array $buffer = [];
 
-    public function __construct(private Reader $reader, private EventParser $parser)
+    public function __construct(private readonly Reader $reader, private readonly EventParser $parser)
     {
     }
 

--- a/lib/term/src/InformationProvider/AggregateInformationProvider.php
+++ b/lib/term/src/InformationProvider/AggregateInformationProvider.php
@@ -12,7 +12,7 @@ class AggregateInformationProvider implements InformationProvider
     /**
      * @param InformationProvider[] $providers
      */
-    public function __construct(private array $providers)
+    public function __construct(private readonly array $providers)
     {
     }
 

--- a/lib/term/src/InformationProvider/ClosureInformationProvider.php
+++ b/lib/term/src/InformationProvider/ClosureInformationProvider.php
@@ -17,7 +17,7 @@ final class ClosureInformationProvider implements InformationProvider
      * @template T of TerminalInformation
      * @param Closure(class-string<T>): (T|null) $closure
      */
-    private function __construct(private Closure $closure)
+    private function __construct(private readonly Closure $closure)
     {
     }
 

--- a/lib/term/src/InformationProvider/SizeFromSttyProvider.php
+++ b/lib/term/src/InformationProvider/SizeFromSttyProvider.php
@@ -12,7 +12,7 @@ use PhpTui\Term\TerminalInformation;
 
 final class SizeFromSttyProvider implements InformationProvider
 {
-    private function __construct(private ProcessRunner $runner)
+    private function __construct(private readonly ProcessRunner $runner)
     {
     }
 

--- a/lib/term/src/Painter/AnsiPainter.php
+++ b/lib/term/src/Painter/AnsiPainter.php
@@ -27,7 +27,7 @@ use RuntimeException;
 
 final class AnsiPainter implements Painter
 {
-    public function __construct(private Writer $writer)
+    public function __construct(private readonly Writer $writer)
     {
     }
 
@@ -62,7 +62,7 @@ final class AnsiPainter implements Painter
         }
 
         if ($action instanceof EnableMouseCapture) {
-            $this->writer->write(implode('', array_map(fn (string $code) => $this->esc($code), $action->enable ? [
+            $this->writer->write(implode('', array_map(fn (string $code): string => $this->esc($code), $action->enable ? [
                 // Normal tracking: Send mouse X & Y on button press and release
                 '?1000h',
                 // Button-event tracking: Report button motion events (dragging)

--- a/lib/term/src/Painter/HtmlCanvasPainter.php
+++ b/lib/term/src/Painter/HtmlCanvasPainter.php
@@ -32,15 +32,15 @@ class HtmlCanvasPainter implements Painter
     /**
      * @var int<1,max>
      */
-    private int $width;
+    private readonly int $width;
 
     private ?SetRgbBackgroundColor $bgColor = null;
 
     private ?SetRgbForegroundColor $fgColor = null;
 
-    private SetRgbBackgroundColor $defaultBgColor;
+    private readonly SetRgbBackgroundColor $defaultBgColor;
 
-    private SetRgbForegroundColor $defaultFgColor;
+    private readonly SetRgbForegroundColor $defaultFgColor;
 
     private function __construct(
         int $width,

--- a/lib/term/src/Painter/StringPainter.php
+++ b/lib/term/src/Painter/StringPainter.php
@@ -40,7 +40,7 @@ class StringPainter implements Painter
         $maxX = max(
             0,
             ...array_map(
-                fn (array $cells) => max(
+                static fn (array $cells): mixed => max(
                     array_keys($cells)
                 ),
                 $this->grid

--- a/lib/term/src/ProcessRunner/ClosureRunner.php
+++ b/lib/term/src/ProcessRunner/ClosureRunner.php
@@ -16,7 +16,7 @@ class ClosureRunner implements ProcessRunner
     /**
      * @param Closure(string[]): ProcessResult $closure
      */
-    public function __construct(private Closure $closure)
+    public function __construct(private readonly Closure $closure)
     {
     }
 

--- a/lib/term/src/RawMode/SttyRawMode.php
+++ b/lib/term/src/RawMode/SttyRawMode.php
@@ -11,9 +11,9 @@ use RuntimeException;
 
 class SttyRawMode implements RawMode
 {
-    private ?string $originalSettings;
+    private ?string $originalSettings = null;
 
-    private function __construct(private ProcessRunner $runner)
+    private function __construct(private readonly ProcessRunner $runner)
     {
     }
 

--- a/lib/term/src/Terminal.php
+++ b/lib/term/src/Terminal.php
@@ -57,9 +57,7 @@ class Terminal
      */
     public function info(string $classFqn): ?object
     {
-        $info = $this->infoProvider->for($classFqn);
-
-        return $info;
+        return $this->infoProvider->for($classFqn);
     }
 
     /**

--- a/lib/term/src/Terminal.php
+++ b/lib/term/src/Terminal.php
@@ -20,10 +20,10 @@ class Terminal
     private array $queue = [];
 
     public function __construct(
-        private Painter $painter,
-        private InformationProvider $infoProvider,
-        private RawMode $rawMode,
-        private EventProvider $eventProvider
+        private readonly Painter $painter,
+        private readonly InformationProvider $infoProvider,
+        private readonly RawMode $rawMode,
+        private readonly EventProvider $eventProvider
     ) {
     }
 

--- a/lib/term/tests/InformationProvider/AggregateInformationProviderTest.php
+++ b/lib/term/tests/InformationProvider/AggregateInformationProviderTest.php
@@ -18,7 +18,7 @@ class AggregateInformationProviderTest extends TestCase
             ClosureInformationProvider::new(function (string $classFqn) {
                 return null;
             }),
-            ClosureInformationProvider::new(function (string $classFqn) use ($info) {
+            ClosureInformationProvider::new(function (string $classFqn) use ($info): ?TestInfo {
                 if ($classFqn !== TestInfo::class) {
                     return null;
                 }

--- a/lib/term/tests/InformationProvider/SizeFromSttyProviderTest.php
+++ b/lib/term/tests/InformationProvider/SizeFromSttyProviderTest.php
@@ -14,7 +14,7 @@ class SizeFromSttyProviderTest extends TestCase
 {
     public function testSizeFromStty(): void
     {
-        $runner = ClosureRunner::new(function (array $command) {
+        $runner = ClosureRunner::new(function (array $command): ProcessResult {
             return new ProcessResult(
                 0,
                 <<<'EOT'

--- a/lib/term/tests/Painter/HtmlCanvasPainterTest.php
+++ b/lib/term/tests/Painter/HtmlCanvasPainterTest.php
@@ -18,59 +18,56 @@ class HtmlCanvasPainterTest extends TestCase
             Actions::moveCursor(2, 5),
             Actions::printString('Worl'),
         ]);
-        self::assertNormalizedEquals(
-            <<<'EOT'
-                <canvas id="term_6553463265112" width=16 height=40></canvas>
-                <script>
-                const canvas = document.getElementById("term_6553463265112");
-                const ctx = canvas.getContext("2d");
-                ctx.font = "12px monospace";
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(0,0,16,40);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(0,0,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("H",0,8);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(8,0,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("e",8,8);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(0,8,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("l",0,16);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(8,8,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("l",8,16);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(0,24,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("W",0,32);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(8,24,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("o",8,32);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(0,32,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("r",0,40);
-                ctx.fillStyle = "rgb(10,10,10)";
-                ctx.fillRect(8,32,8,8);
-                ctx.fillStyle = "rgb(255,255,255)";
-                ctx.fillText("l",8,40);
-                </script>
-                EOT,
-            $painter->toString()
-        );
+        $this->assertNormalizedEquals(<<<'EOT'
+            <canvas id="term_6553463265112" width=16 height=40></canvas>
+            <script>
+            const canvas = document.getElementById("term_6553463265112");
+            const ctx = canvas.getContext("2d");
+            ctx.font = "12px monospace";
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(0,0,16,40);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(0,0,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("H",0,8);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(8,0,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("e",8,8);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(0,8,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("l",0,16);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(8,8,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("l",8,16);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(0,24,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("W",0,32);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(8,24,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("o",8,32);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(0,32,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("r",0,40);
+            ctx.fillStyle = "rgb(10,10,10)";
+            ctx.fillRect(8,32,8,8);
+            ctx.fillStyle = "rgb(255,255,255)";
+            ctx.fillText("l",8,40);
+            </script>
+            EOT, $painter->toString());
     }
 
-    private static function assertNormalizedEquals(string $string, string $string2): void
+    private function assertNormalizedEquals(string $string, string $string2): void
     {
-        self::assertEquals(self::normalize($string), self::normalize($string2));
+        self::assertEquals($this->normalize($string), $this->normalize($string2));
     }
 
-    private static function normalize(string $string): string
+    private function normalize(string $string): string
     {
         $normalized = preg_replace('{canvas id=".*?"}', 'canvas id=***', $string);
         $normalized = preg_replace('{getElementById\(".*?"\)}', 'getElementById(***)', (string)$normalized);

--- a/lib/term/tests/RawMode/SttyRawModeTest.php
+++ b/lib/term/tests/RawMode/SttyRawModeTest.php
@@ -15,7 +15,7 @@ class SttyRawModeTest extends TestCase
     public function testEnableDisable(): void
     {
         $called = [];
-        $runner = ClosureRunner::new(function (array $command) use (&$called) {
+        $runner = ClosureRunner::new(function (array $command) use (&$called): ProcessResult {
             if ($command === ['stty', '-g']) {
                 $called[] = $command;
 

--- a/lib/term/tests/TerminalTest.php
+++ b/lib/term/tests/TerminalTest.php
@@ -65,7 +65,7 @@ final class TerminalTest extends TestCase
                 'SetModifier(Hidden,on)',
                 'SetModifier(Strike,on)',
             ],
-            array_map(fn (Action $cmd) => $cmd->__toString(), $dummy->actions())
+            array_map(static fn (Action $cmd): string => $cmd->__toString(), $dummy->actions())
         );
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
+use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\Config\RectorConfig;
 use Rector\Php53\Rector\Ternary\TernaryToElvisRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
@@ -29,6 +31,8 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rules([
         StaticArrowFunctionRector::class,
+        EncapsedStringsToSprintfRector::class,
+        UnwrapSprintfOneArgumentRector::class,
     ]);
 
     $rectorConfig->sets([

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
+use Rector\Config\RectorConfig;
+use Rector\Php53\Rector\Ternary\TernaryToElvisRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->parallel();
+    $rectorConfig->importShortClasses();
+
+    $rectorConfig->paths([
+        __DIR__ . '/lib',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $rectorConfig->skip([
+        TernaryToElvisRector::class,
+        ClosureToArrowFunctionRector::class,
+    ]);
+
+    $rectorConfig->rules([
+        StaticArrowFunctionRector::class,
+    ]);
+
+    $rectorConfig->sets([
+        SetList::TYPE_DECLARATION,
+        LevelSetList::UP_TO_PHP_81,
+    ]);
+};

--- a/rector.php
+++ b/rector.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
 use Rector\Config\RectorConfig;
 use Rector\Php53\Rector\Ternary\TernaryToElvisRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->parallel();
+    $rectorConfig->importNames();
     $rectorConfig->importShortClasses();
 
     $rectorConfig->paths([
@@ -21,6 +23,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->skip([
         TernaryToElvisRector::class,
+        JsonThrowOnErrorRector::class,
         ClosureToArrowFunctionRector::class,
     ]);
 

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
 use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
+use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\Config\RectorConfig;
@@ -26,7 +29,10 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->skip([
         TernaryToElvisRector::class,
         JsonThrowOnErrorRector::class,
+        ExplicitBoolCompareRector::class,
         ClosureToArrowFunctionRector::class,
+        UnusedForeachValueToArrayKeysRector::class,
+        FlipTypeControlToUseExclusiveTypeRector::class,
     ]);
 
     $rectorConfig->rules([
@@ -36,6 +42,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->sets([
+        SetList::CODE_QUALITY,
         SetList::TYPE_DECLARATION,
         LevelSetList::UP_TO_PHP_81,
     ]);

--- a/src/Bridge/Cassowary/CassowaryConstraintSolver.php
+++ b/src/Bridge/Cassowary/CassowaryConstraintSolver.php
@@ -59,13 +59,13 @@ final class CassowaryConstraintSolver implements ConstraintSolver
         }
 
         // ensure the first element toches the left/top edge of the area
-        if (count($elements)) {
+        if ($elements !== []) {
             $first = $elements[array_key_first($elements)];
             $solver->addConstraint(Constraint::equalTo($first->start, $areaStart, Strength::REQUIRED));
         }
 
         // ensure the last element touches the right/boottom edge of the area
-        if (count($elements)) {
+        if ($elements !== []) {
             $last = $elements[array_key_last($elements)];
             $solver->addConstraint(Constraint::equalTo($last->end, $areaEnd, Strength::REQUIRED));
         }

--- a/src/Bridge/Cassowary/CassowaryConstraintSolver.php
+++ b/src/Bridge/Cassowary/CassowaryConstraintSolver.php
@@ -33,7 +33,7 @@ final class CassowaryConstraintSolver implements ConstraintSolver
 
         $areaSize = $areaEnd - $areaStart;
 
-        $elements = array_map(fn () => Element::empty(), $layout->constraints);
+        $elements = array_map(static fn (): Element => Element::empty(), $layout->constraints);
 
         // ensure that all the elements are inside the area
         foreach ($elements as $element) {

--- a/src/Bridge/PhpTerm/PhpTermBackend.php
+++ b/src/Bridge/PhpTerm/PhpTermBackend.php
@@ -32,7 +32,7 @@ use RuntimeException;
 
 class PhpTermBackend implements Backend
 {
-    public function __construct(private PhpTermTerminal $terminal)
+    public function __construct(private readonly PhpTermTerminal $terminal)
     {
     }
 

--- a/src/Bridge/PhpTerm/PhpTermBackend.php
+++ b/src/Bridge/PhpTerm/PhpTermBackend.php
@@ -126,9 +126,7 @@ class PhpTermBackend implements Backend
         while(true) {
             while (null !== $event = $this->terminal->events()->next()) {
                 if ($event instanceof CursorPositionEvent) {
-                    $pos = new Position($event->x, $event->y);
-
-                    return $pos;
+                    return new Position($event->x, $event->y);
                 }
             }
 

--- a/src/DisplayBuilder.php
+++ b/src/DisplayBuilder.php
@@ -50,7 +50,7 @@ final class DisplayBuilder
      * @param DisplayExtension[] $extensions
      */
     private function __construct(
-        private Backend $backend,
+        private readonly Backend $backend,
         private ?Viewport $viewport,
         private array $extensions
     ) {

--- a/src/Extension/Bdf/BdfExtension.php
+++ b/src/Extension/Bdf/BdfExtension.php
@@ -9,7 +9,7 @@ use PhpTui\Tui\Model\Display\DisplayExtension;
 
 class BdfExtension implements DisplayExtension
 {
-    public function __construct(private ?FontRegistry $registry = null)
+    public function __construct(private readonly ?FontRegistry $registry = null)
     {
     }
 

--- a/src/Extension/Bdf/FontRegistry.php
+++ b/src/Extension/Bdf/FontRegistry.php
@@ -21,7 +21,7 @@ final class FontRegistry
     /**
      * @param array<string,string> $fontMap
      */
-    public function __construct(private BdfParser $parser, private array $fontMap = [])
+    public function __construct(private readonly BdfParser $parser, private array $fontMap = [])
     {
     }
 

--- a/src/Extension/Bdf/Shape/TextRenderer.php
+++ b/src/Extension/Bdf/Shape/TextRenderer.php
@@ -14,7 +14,7 @@ use PhpTui\Tui\Model\Position\FloatPosition;
 class TextRenderer implements ShapePainter
 {
     public function __construct(
-        private FontRegistry $registry,
+        private readonly FontRegistry $registry,
     ) {
     }
 

--- a/src/Extension/Bdf/Shape/TextRenderer.php
+++ b/src/Extension/Bdf/Shape/TextRenderer.php
@@ -29,15 +29,15 @@ class TextRenderer implements ShapePainter
         foreach (str_split($shape->text) as $char) {
             $glyph = $font->codePoint(ord($char));
 
-            $grid = self::buildGrid($shape, $glyph);
-            $charOffset += self::renderChar($shape, $painter, $charOffset, $grid, $glyph);
+            $grid = $this->buildGrid($shape, $glyph);
+            $charOffset += $this->renderChar($shape, $painter, $charOffset, $grid, $glyph);
         }
     }
 
     /**
      * @return list<array<int,bool>>
      */
-    private static function buildGrid(TextShape $shape, BdfGlyph $glyph): array
+    private function buildGrid(TextShape $shape, BdfGlyph $glyph): array
     {
         $grid = [];
         $y = 0;
@@ -46,7 +46,7 @@ class TextRenderer implements ShapePainter
             for ($i = $glyph->boundingBox->size->width + 1; $i >= 0; $i--) {
                 $x = $i + $shape->position->x;
                 $grid[$y][$x] = ($row & $xbit) > 0;
-                $xbit = $xbit << 1;
+                $xbit <<= 1;
             }
             $y++;
         }
@@ -57,7 +57,7 @@ class TextRenderer implements ShapePainter
     /**
      * @param array<int,array<int,bool>> $grid
      */
-    private static function renderChar(
+    private function renderChar(
         TextShape $shape,
         Painter $painter,
         float $charOffset,

--- a/src/Extension/Core/Shape/LinePainter.php
+++ b/src/Extension/Core/Shape/LinePainter.php
@@ -28,8 +28,8 @@ class LinePainter implements ShapePainter
             return;
         }
 
-        [$diffX, $xRange] = self::resolveDiffAndRange($point1->x, $point2->x);
-        [$diffY, $yRange] = self::resolveDiffAndRange($point1->y, $point2->y);
+        [$diffX, $xRange] = $this->resolveDiffAndRange($point1->x, $point2->x);
+        [$diffY, $yRange] = $this->resolveDiffAndRange($point1->y, $point2->y);
 
         if ($diffX === 0) {
             foreach ($yRange as $y) {
@@ -69,7 +69,7 @@ class LinePainter implements ShapePainter
     /**
      * @return array{int, int[]}
      */
-    private static function resolveDiffAndRange(int $start, int $end): array
+    private function resolveDiffAndRange(int $start, int $end): array
     {
         if ($end >= $start) {
             return [$end - $start, range($start, $end)];

--- a/src/Extension/Core/Shape/SpritePainter.php
+++ b/src/Extension/Core/Shape/SpritePainter.php
@@ -18,7 +18,7 @@ class SpritePainter implements ShapePainter
             return;
         }
 
-        $maxX = max(0, ...array_map(fn (string $row) => mb_strlen($row), $shape->rows));
+        $maxX = max(0, ...array_map(static fn (string $row): int => mb_strlen($row), $shape->rows));
         $xStep = $painter->context->xBounds->length() / $painter->resolution->width;
         $yStep = $painter->context->yBounds->length() / $painter->resolution->height;
         $pixelWidth = $shape->xScale;

--- a/src/Extension/Core/Widget/BarChart/BarGroup.php
+++ b/src/Extension/Core/Widget/BarChart/BarGroup.php
@@ -28,7 +28,7 @@ class BarGroup
      */
     public static function fromArray(array $array): self
     {
-        return new self(null, array_map(function (string|int $key, int $value) {
+        return new self(null, array_map(function (string|int $key, int $value): Bar {
             $key = (string)$key;
 
             return new Bar($value, Line::fromString($key), Style::default(), Style::default(), null);
@@ -49,7 +49,7 @@ class BarGroup
 
     public function max(): int
     {
-        return array_reduce($this->bars, function (int $max, Bar $bar) {
+        return array_reduce($this->bars, function (int $max, Bar $bar): int {
             $value = $bar->value;
             if ($value > $max) {
                 return $value;

--- a/src/Extension/Core/Widget/BarChartRenderer.php
+++ b/src/Extension/Core/Widget/BarChartRenderer.php
@@ -74,7 +74,7 @@ final class BarChartRenderer implements WidgetRenderer
                 return $ticks;
             }
 
-            $ticks[] = array_map(function (Bar $bar) use ($barMaxLength, $max) {
+            $ticks[] = array_map(function (Bar $bar) use ($barMaxLength, $max): int {
                 if ($max === 0) {
                     return 0;
                 }
@@ -92,7 +92,7 @@ final class BarChartRenderer implements WidgetRenderer
             return $widget->max;
         }
 
-        return array_reduce($widget->data, function (int $max, BarGroup $barGroup) {
+        return array_reduce($widget->data, function (int $max, BarGroup $barGroup): int {
             $barGroupMax = $barGroup->max();
             if ($barGroupMax > $max) {
                 return $barGroupMax;

--- a/src/Extension/Core/Widget/BarChartRenderer.php
+++ b/src/Extension/Core/Widget/BarChartRenderer.php
@@ -303,7 +303,7 @@ final class BarChartRenderer implements WidgetRenderer
                 $barStyle = $widget->barStyle->patch($bar->style);
 
                 for ($y = 0; $y < $widget->barWidth; $y++) {
-                    $barY = $barY + $y;
+                    $barY += $y;
                     if ($barY >= $barsArea->bottom()) {
                         continue;
                     }

--- a/src/Extension/Core/Widget/BlockRenderer.php
+++ b/src/Extension/Core/Widget/BlockRenderer.php
@@ -116,7 +116,7 @@ final class BlockRenderer implements WidgetRenderer
         $offset = $rightBorderDx;
         foreach (array_filter(
             $block->titles,
-            function (Title $title) use ($alignment) {
+            function (Title $title) use ($alignment): bool {
                 return
                     $title->horizontalAlignment === HorizontalAlignment::Right
                     && $title->verticalAlignment === $alignment;
@@ -145,7 +145,7 @@ final class BlockRenderer implements WidgetRenderer
         $offset = $leftBorderDx;
         foreach (array_filter(
             $block->titles,
-            function (Title $title) use ($alignment) {
+            function (Title $title) use ($alignment): bool {
                 return
                     $title->horizontalAlignment === HorizontalAlignment::Left
                     && $title->verticalAlignment === $alignment;
@@ -178,7 +178,7 @@ final class BlockRenderer implements WidgetRenderer
         [$_, $_, $titleAreaWidth] = $this->calculateTitleAreaOffsets($block, $area);
         $titles = array_filter(
             $block->titles,
-            function (Title $title) use ($alignment) {
+            function (Title $title) use ($alignment): bool {
                 return
                     $title->horizontalAlignment === HorizontalAlignment::Center
                     && $title->verticalAlignment === $alignment;
@@ -186,7 +186,7 @@ final class BlockRenderer implements WidgetRenderer
         );
         $sumWidth = array_reduce(
             $titles,
-            fn (int $acc, Title $title) => $acc + $title->title->width(),
+            static fn (int $acc, Title $title): int => $acc + $title->title->width(),
             0
         );
         $offset = (int) (max(0, $area->width - $sumWidth) / 2);

--- a/src/Extension/Core/Widget/ChartRenderer.php
+++ b/src/Extension/Core/Widget/ChartRenderer.php
@@ -166,7 +166,7 @@ final class ChartRenderer implements WidgetRenderer
             $chartArea,
             $layout->graphArea
         );
-        self::renderLabel($buffer, $firstLabel, $labelArea, $labelAlignment);
+        $this->renderLabel($buffer, $firstLabel, $labelArea, $labelAlignment);
 
         $lastLabel = array_pop($labels);
         if (null === $lastLabel) {
@@ -175,11 +175,11 @@ final class ChartRenderer implements WidgetRenderer
         foreach ($labels as $i => $label) {
             $x = $layout->graphArea->left() + ($i + 1) * $widthBetweenTicks + 1;
             $labelArea = Area::fromScalars($x, $layout->labelX, $widthBetweenTicks - 1, 1);
-            self::renderLabel($buffer, $label, $labelArea, HorizontalAlignment::Center);
+            $this->renderLabel($buffer, $label, $labelArea, HorizontalAlignment::Center);
         }
         $x = $layout->graphArea->right() - $widthBetweenTicks;
         $labelArea = Area::fromScalars($x, $layout->labelX, $widthBetweenTicks, 1);
-        self::renderLabel($buffer, $lastLabel, $labelArea, HorizontalAlignment::Center);
+        $this->renderLabel($buffer, $lastLabel, $labelArea, HorizontalAlignment::Center);
 
     }
 
@@ -197,7 +197,7 @@ final class ChartRenderer implements WidgetRenderer
         return Area::fromScalars($minX, $y, $maxX - $minX, 1);
     }
 
-    private static function renderLabel(Buffer $buffer, Span $label, Area $labelArea, HorizontalAlignment $labelAlignment): void
+    private function renderLabel(Buffer $buffer, Span $label, Area $labelArea, HorizontalAlignment $labelAlignment): void
     {
         $boundedLabelWidth = min($labelArea->width, $label->width());
         $x = match ($labelAlignment) {
@@ -228,7 +228,7 @@ final class ChartRenderer implements WidgetRenderer
                     max(0, ($layout->graphArea->left() - $chartArea->left()) - 1),
                     1
                 );
-                self::renderLabel($buffer, $label, $labelArea, $chart->yAxis->labelAlignment);
+                $this->renderLabel($buffer, $label, $labelArea, $chart->yAxis->labelAlignment);
             }
         }
     }

--- a/src/Extension/Core/Widget/ChartRenderer.php
+++ b/src/Extension/Core/Widget/ChartRenderer.php
@@ -121,7 +121,7 @@ final class ChartRenderer implements WidgetRenderer
     private function maxWidthOfLabelsLeftOfYAxis(ChartWidget $chart, Area $area, bool $hasYAxis): int
     {
         $maxWidth = $chart->yAxis->labels ? max(
-            ...array_map(function (Span $label) {
+            ...array_map(function (Span $label): int {
                 return $label->width();
             }, $chart->yAxis->labels)
         ) : 0;

--- a/src/Extension/Core/Widget/ClosureRenderer.php
+++ b/src/Extension/Core/Widget/ClosureRenderer.php
@@ -14,7 +14,7 @@ final class ClosureRenderer implements WidgetRenderer
     /**
      * @param Closure(WidgetRenderer, Widget, Buffer): void $renderer
      */
-    public function __construct(private Closure $renderer)
+    public function __construct(private readonly Closure $renderer)
     {
     }
 

--- a/src/Extension/Core/Widget/DefaultWidgetSet.php
+++ b/src/Extension/Core/Widget/DefaultWidgetSet.php
@@ -10,7 +10,7 @@ use PhpTui\Tui\Model\WidgetSet;
 
 class DefaultWidgetSet implements WidgetSet
 {
-    public function __construct(private ShapePainter $shapePainter)
+    public function __construct(private readonly ShapePainter $shapePainter)
     {
     }
 

--- a/src/Extension/Core/Widget/ListRenderer.php
+++ b/src/Extension/Core/Widget/ListRenderer.php
@@ -39,7 +39,7 @@ class ListRenderer implements WidgetRenderer
         $currentHeight = 0;
         $selectionSpacing = $widget->highlightSpacing->shouldAdd($widget->state->selected !== null);
         foreach (array_slice($widget->items, $start, $end - $start) as $i => $item) {
-            [$x, $y, $currentHeight] = (function () use ($item, $listArea, $currentHeight, $widget) {
+            [$x, $y, $currentHeight] = (function () use ($item, $listArea, $currentHeight, $widget): array {
                 if ($widget->startCorner === Corner::BottomLeft) {
                     $currentHeight += $item->height();
 
@@ -63,7 +63,7 @@ class ListRenderer implements WidgetRenderer
                     $blankSymbol
                 ;
 
-                [$elemPosition, $maxElementWidth] = (function () use ($listArea, $selectionSpacing, $buffer, $x, $j, $y, $symbol, $itemStyle) {
+                [$elemPosition, $maxElementWidth] = (function () use ($listArea, $selectionSpacing, $buffer, $x, $j, $y, $symbol, $itemStyle): array {
                     if ($selectionSpacing === true) {
                         $pos = $buffer->putString(
                             Position::at($x, $y + $j),

--- a/src/Extension/Core/Widget/ListRenderer.php
+++ b/src/Extension/Core/Widget/ListRenderer.php
@@ -28,7 +28,7 @@ class ListRenderer implements WidgetRenderer
             return;
         }
 
-        if (count($widget->items) === 0) {
+        if ($widget->items === []) {
             return;
         }
         $listHeight = $listArea->height;
@@ -64,7 +64,7 @@ class ListRenderer implements WidgetRenderer
                 ;
 
                 [$elemPosition, $maxElementWidth] = (function () use ($listArea, $selectionSpacing, $buffer, $x, $j, $y, $symbol, $itemStyle): array {
-                    if ($selectionSpacing === true) {
+                    if ($selectionSpacing) {
                         $pos = $buffer->putString(
                             Position::at($x, $y + $j),
                             $symbol,

--- a/src/Extension/Core/Widget/ParagraphRenderer.php
+++ b/src/Extension/Core/Widget/ParagraphRenderer.php
@@ -34,8 +34,8 @@ class ParagraphRenderer implements WidgetRenderer
 
         $widget->text->patchStyle($widget->style);
         $style = $widget->style;
-        $styled = array_map(function (Line $line) use ($style, $widget) {
-            $graphemes = array_reduce($line->spans, function (array $ac, Span $span) use ($style) {
+        $styled = array_map(function (Line $line) use ($style, $widget): array {
+            $graphemes = array_reduce($line->spans, function (array $ac, Span $span) use ($style): array {
                 foreach ($span->toStyledGraphemes($style) as $grapheme) {
                     $ac[] = $grapheme;
                 }

--- a/src/Extension/Core/Widget/ParagraphRenderer.php
+++ b/src/Extension/Core/Widget/ParagraphRenderer.php
@@ -59,7 +59,7 @@ class ParagraphRenderer implements WidgetRenderer
 
             if ($y >= $widget->scroll[0]) {
 
-                $x = self::getLineOffset($currentLineWidth, $textArea->width, $currentLineAlignment);
+                $x = $this->getLineOffset($currentLineWidth, $textArea->width, $currentLineAlignment);
 
                 foreach ($currentLine as $grapheme) {
                     if ($grapheme->symbolWidth() === 0) {
@@ -90,7 +90,7 @@ class ParagraphRenderer implements WidgetRenderer
         return new LineTruncator($styled, $textArea->width, $horizontalOffset);
     }
 
-    private static function getLineOffset(int $width, int $maxWidth, HorizontalAlignment $alignment): int
+    private function getLineOffset(int $width, int $maxWidth, HorizontalAlignment $alignment): int
     {
         return match ($alignment) {
             HorizontalAlignment::Center => (int) (($maxWidth / 2) - $width / 2),

--- a/src/Extension/Core/Widget/Table/TableRow.php
+++ b/src/Extension/Core/Widget/Table/TableRow.php
@@ -26,7 +26,7 @@ final class TableRow
 
     public static function fromStrings(string ...$strings): self
     {
-        return new self(array_map(function (string $string) {
+        return new self(array_map(function (string $string): TableCell {
             return TableCell::fromString($string);
         }, array_values($strings)), 1, 0, Style::default());
     }

--- a/src/Extension/Core/Widget/TableRenderer.php
+++ b/src/Extension/Core/Widget/TableRenderer.php
@@ -56,21 +56,17 @@ final class TableRenderer implements WidgetRenderer
                 if (null === $cell) {
                     continue;
                 }
-                self::renderCell(
-                    $buffer,
-                    $cell,
-                    Area::fromScalars(
-                        $innerOffset + $width[0],
-                        $tableArea->top(),
-                        $width[1],
-                        $maxHeaderHight
-                    )
-                );
+                $this->renderCell($buffer, $cell, Area::fromScalars(
+                    $innerOffset + $width[0],
+                    $tableArea->top(),
+                    $width[1],
+                    $maxHeaderHight
+                ));
             }
             $currentHeight += $maxHeaderHight;
             $rowsHeight = max(0, $rowsHeight - $maxHeaderHight);
         }
-        if (count($widget->rows) === 0) {
+        if ($widget->rows === []) {
             return;
         }
 
@@ -99,16 +95,12 @@ final class TableRenderer implements WidgetRenderer
                 if (null === $cell) {
                     continue;
                 }
-                self::renderCell(
-                    $buffer,
-                    $cell,
-                    Area::fromScalars(
-                        $innerOffset + $width[0],
-                        $rowY,
-                        $width[1],
-                        $tableRow->height,
-                    )
-                );
+                $this->renderCell($buffer, $cell, Area::fromScalars(
+                    $innerOffset + $width[0],
+                    $rowY,
+                    $width[1],
+                    $tableRow->height,
+                ));
             }
             if ($isSelected) {
                 $buffer->setStyle($tableRowArea, $widget->highlightStyle);
@@ -128,7 +120,7 @@ final class TableRenderer implements WidgetRenderer
             $constraints[] = $constraint;
             $constraints[] = Constraint::length($table->columnSpacing);
         }
-        if (0 !== count($table->widths)) {
+        if ([] !== $table->widths) {
             array_pop($constraints);
         }
         $chunks = Layout::default()
@@ -137,9 +129,11 @@ final class TableRenderer implements WidgetRenderer
             ->split(Area::fromDimensions($maxWidth, 1));
 
         $widths = [];
+        // iterate over the specified width constraints
+        $counter = count($constraints);
 
         // iterate over the specified width constraints
-        for ($i = 1; $i < count($constraints); $i += 2) {
+        for ($i = 1; $i < $counter; $i += 2) {
             $chunk = $chunks->get($i);
             $widths[] = [$chunk->position->x, $chunk->width];
         }
@@ -147,7 +141,7 @@ final class TableRenderer implements WidgetRenderer
         return $widths;
     }
 
-    private static function renderCell(Buffer $buffer, TableCell $cell, Area $area): void
+    private function renderCell(Buffer $buffer, TableCell $cell, Area $area): void
     {
         $buffer->setStyle($area, $cell->style);
         foreach ($cell->content->lines as $i => $line) {

--- a/src/Extension/ImageMagick/ImageMagickExtension.php
+++ b/src/Extension/ImageMagick/ImageMagickExtension.php
@@ -10,7 +10,7 @@ use PhpTui\Tui\Model\Display\DisplayExtension;
 
 final class ImageMagickExtension implements DisplayExtension
 {
-    public function __construct(private ?ImageRegistry $imageRegistry = null)
+    public function __construct(private readonly ?ImageRegistry $imageRegistry = null)
     {
     }
 

--- a/src/Extension/ImageMagick/Shape/ImagePainter.php
+++ b/src/Extension/ImageMagick/Shape/ImagePainter.php
@@ -18,7 +18,7 @@ use PhpTui\Tui\Model\Text\Line as PhpTuiLine;
 
 final class ImagePainter implements ShapePainter
 {
-    private ImageRegistry $registry;
+    private readonly ImageRegistry $registry;
 
     public function __construct(ImageRegistry $registry = null)
     {

--- a/src/Extension/ImageMagick/Widget/ImageRenderer.php
+++ b/src/Extension/ImageMagick/Widget/ImageRenderer.php
@@ -14,7 +14,7 @@ use PhpTui\Tui\Model\WidgetRenderer;
 
 class ImageRenderer implements WidgetRenderer
 {
-    public function __construct(private ImageRegistry $registry)
+    public function __construct(private readonly ImageRegistry $registry)
     {
     }
 

--- a/src/Model/Canvas/AggregateShapePainter.php
+++ b/src/Model/Canvas/AggregateShapePainter.php
@@ -15,7 +15,7 @@ class AggregateShapePainter implements ShapePainter
     /**
      * @param ShapePainter[] $painters
      */
-    public function __construct(private array $painters)
+    public function __construct(private readonly array $painters)
     {
     }
 

--- a/src/Model/Canvas/CanvasContext.php
+++ b/src/Model/Canvas/CanvasContext.php
@@ -18,7 +18,7 @@ use PhpTui\Tui\Model\Text\Line;
 final class CanvasContext
 {
     private function __construct(
-        private ShapePainter $painter,
+        private readonly ShapePainter $painter,
         public AxisBounds $xBounds,
         public AxisBounds $yBounds,
         public CanvasGrid $grid,

--- a/src/Model/Canvas/Grid/BrailleGrid.php
+++ b/src/Model/Canvas/Grid/BrailleGrid.php
@@ -26,8 +26,8 @@ final class BrailleGrid extends CanvasGrid
      * @param Color[] $colors
      */
     private function __construct(
-        private int $width,
-        private int $height,
+        private readonly int $width,
+        private readonly int $height,
         private array $codePoints,
         private array $colors
     ) {
@@ -56,15 +56,15 @@ final class BrailleGrid extends CanvasGrid
             return $this->brailleCharCache[$point] ??= IntlChar::chr($point);
         }, $this->codePoints);
 
-        $colors = array_map(fn (Color $color) => new FgBgColor($color, AnsiColor::Reset), $this->colors);
+        $colors = array_map(static fn (Color $color): FgBgColor => new FgBgColor($color, AnsiColor::Reset), $this->colors);
 
         return new Layer(chars: $chars, colors: $colors);
     }
 
     public function reset(): void
     {
-        $this->codePoints = array_map(fn () => BrailleSet::BLANK, $this->codePoints);
-        $this->colors = array_map(fn () => AnsiColor::Reset, $this->colors);
+        $this->codePoints = array_map(static fn (): int => BrailleSet::BLANK, $this->codePoints);
+        $this->colors = array_map(static fn (): AnsiColor => AnsiColor::Reset, $this->colors);
     }
 
     public function paint(Position $position, Color $color): void

--- a/src/Model/Canvas/Grid/CharGrid.php
+++ b/src/Model/Canvas/Grid/CharGrid.php
@@ -19,7 +19,7 @@ final class CharGrid extends CanvasGrid
      * @param Color[] $colors
      */
     private function __construct(
-        private Resolution $resolution,
+        private readonly Resolution $resolution,
         private array $cells,
         private array $colors,
         private string $cellChar
@@ -47,14 +47,14 @@ final class CharGrid extends CanvasGrid
     {
         return new Layer(
             chars: $this->cells,
-            colors: array_map(fn (Color $color) => new FgBgColor($color, AnsiColor::Reset), $this->colors),
+            colors: array_map(static fn (Color $color): FgBgColor => new FgBgColor($color, AnsiColor::Reset), $this->colors),
         );
     }
 
     public function reset(): void
     {
-        $this->cells = array_map(fn ($_) => ' ', $this->cells);
-        $this->colors = array_map(fn ($_) => AnsiColor::Reset, $this->colors);
+        $this->cells = array_map(static fn (): string => ' ', $this->cells);
+        $this->colors = array_map(static fn (): AnsiColor => AnsiColor::Reset, $this->colors);
     }
 
     public function paint(Position $position, Color $color): void

--- a/src/Model/Canvas/Grid/HalfBlockGrid.php
+++ b/src/Model/Canvas/Grid/HalfBlockGrid.php
@@ -16,7 +16,7 @@ use PhpTui\Tui\Model\Symbol\BlockSet;
 class HalfBlockGrid extends CanvasGrid
 {
     public function __construct(
-        private Resolution $resolution,
+        private readonly Resolution $resolution,
         /**
          * @var list<list<Color>>
          */
@@ -34,8 +34,8 @@ class HalfBlockGrid extends CanvasGrid
         return new self(
             new Resolution($width, $height),
             array_map(
-                fn () => array_map(
-                    fn () => AnsiColor::Reset,
+                static fn (): array => array_map(
+                    static fn (): AnsiColor => AnsiColor::Reset,
                     range(1, $width)
                 ),
                 range(1, $height * 2)
@@ -66,7 +66,7 @@ class HalfBlockGrid extends CanvasGrid
         }
 
         $chars = [];
-        $chars = array_map(function (array $pair) {
+        $chars = array_map(function (array $pair): string {
             [$upper, $lower] = $pair;
             if ($upper === AnsiColor::Reset && $lower === AnsiColor::Reset) {
                 return ' ';
@@ -84,7 +84,7 @@ class HalfBlockGrid extends CanvasGrid
 
             return BlockSet::UPPER_HALF;
         }, $paired);
-        $colors = array_map(function (array $pair) {
+        $colors = array_map(function (array $pair): FgBgColor {
             [$upper, $lower] = $pair;
             if ($upper === AnsiColor::Reset && $lower === AnsiColor::Reset) {
                 return new FgBgColor(AnsiColor::Reset, AnsiColor::Reset);

--- a/src/Model/Canvas/Labels.php
+++ b/src/Model/Canvas/Labels.php
@@ -38,7 +38,7 @@ class Labels implements IteratorAggregate
 
     public function withinBounds(AxisBounds $xBounds, AxisBounds $yBounds): self
     {
-        return new self(array_filter($this->labels, function (Label $label) use ($xBounds, $yBounds) {
+        return new self(array_filter($this->labels, function (Label $label) use ($xBounds, $yBounds): bool {
             return $xBounds->contains($label->position->x) && $yBounds->contains($label->position->y);
         }));
     }

--- a/src/Model/Color/LinearGradient.php
+++ b/src/Model/Color/LinearGradient.php
@@ -16,7 +16,7 @@ final class LinearGradient implements Color
     /**
      * @param non-empty-list<array{float,RgbColor}> $stops
      */
-    private function __construct(private array $stops, private float $angle, private FractionalPosition $origin)
+    private function __construct(private array $stops, private readonly float $angle, private readonly FractionalPosition $origin)
     {
     }
 
@@ -54,7 +54,7 @@ final class LinearGradient implements Color
             'LinearGradient(deg: %d, origin: %s, stops: [%s])',
             rad2deg($this->angle),
             $this->origin->__toString(),
-            implode(', ', array_map(function (array $stop) {
+            implode(', ', array_map(function (array $stop): string {
                 return sprintf('%s@%.2f', $stop[1]->debugName(), $stop[0]);
             }, $this->stops))
         );
@@ -92,7 +92,7 @@ final class LinearGradient implements Color
     {
         // determine last stop
         $stops = $this->stops;
-        usort($stops, fn (array $s1, array $s2) => $s1[0] <=> $s2[0]);
+        usort($stops, static fn (array $s1, array $s2): int => $s1[0] <=> $s2[0]);
         [$lastPosition, $lastStop] = array_shift($stops);
 
         $nextStop = null;

--- a/src/Model/Color/RgbColor.php
+++ b/src/Model/Color/RgbColor.php
@@ -149,7 +149,7 @@ class RgbColor implements Color, Stringable
         }
 
         if (!preg_match('/^[a-fA-F0-9]{6}$/', $hex)) {
-            throw new InvalidArgumentException("Invalid hex color: $hex");
+            throw new InvalidArgumentException(sprintf('Invalid hex color: %s', $hex));
         }
 
         $int = hexdec($hex);

--- a/src/Model/Display/Backend/DummyBackend.php
+++ b/src/Model/Display/Backend/DummyBackend.php
@@ -19,12 +19,9 @@ final class DummyBackend implements Backend
 
     private ?string $flushed = null;
 
-    private Position $cursorPosition;
-
-    public function __construct(private int $width, private int $height, ?Position $cursorPosition = null)
+    public function __construct(private int $width, private int $height, private Position $cursorPosition = new Position(0, 0))
     {
         $this->fillGrid($width, $height);
-        $this->cursorPosition = $cursorPosition ?? new Position(0, 0);
     }
 
     public function flushed(): ?string
@@ -46,7 +43,7 @@ final class DummyBackend implements Backend
 
     public function toString(): string
     {
-        return implode("\n", array_map(function (array $cells) {
+        return implode("\n", array_map(function (array $cells): string {
             return implode('', $cells);
         }, $this->grid));
     }
@@ -84,7 +81,7 @@ final class DummyBackend implements Backend
 
     public function appendLines(int $linesAfterCursor): void
     {
-        $this->cursorPosition = $this->cursorPosition->change(fn (int $x, int $y) => [0, $y + $linesAfterCursor]);
+        $this->cursorPosition = $this->cursorPosition->change(static fn (int $x, int $y): array => [0, $y + $linesAfterCursor]);
     }
 
     public function moveCursor(Position $position): void

--- a/src/Model/Display/Buffer.php
+++ b/src/Model/Display/Buffer.php
@@ -97,8 +97,9 @@ final class Buffer implements Countable, Stringable
         $previous = $this->content();
         $next     = $buffer->content();
         $updates = [];
+        $counter = count($next);
 
-        for ($i = 0; $i < count($next); $i++) {
+        for ($i = 0; $i < $counter; $i++) {
             $previousCell = $previous[$i];
             $currentCell = $next[$i];
             if (false === $previousCell->equals($currentCell)) {
@@ -161,9 +162,8 @@ final class Buffer implements Countable, Stringable
     public function toLines(): array
     {
         $text = $this->toString();
-        $lines = explode("\n", $text);
 
-        return $lines;
+        return explode("\n", $text);
     }
 
     public function area(): Area

--- a/src/Model/Display/Buffer.php
+++ b/src/Model/Display/Buffer.php
@@ -11,8 +11,9 @@ use PhpTui\Tui\Model\Position\Position;
 use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Text\Line;
 use PhpTui\Tui\Model\Text\Span;
+use Stringable;
 
-final class Buffer implements Countable
+final class Buffer implements Countable, Stringable
 {
     /**
      * @param Cell[] $content
@@ -71,7 +72,7 @@ final class Buffer implements Countable
         $height = count($lines);
         $width = array_reduce(
             $lines,
-            fn ($acc, $line) => mb_strlen($line) > $acc ? mb_strlen($line) : $acc,
+            static fn ($acc, $line) => mb_strlen($line) > $acc ? mb_strlen($line) : $acc,
             0
         );
 
@@ -129,11 +130,11 @@ final class Buffer implements Countable
 
     public function putString(Position $position, string $line, ?Style $style = null, int $width = PHP_INT_MAX): Position
     {
-        $style = $style ?? Style::default();
+        $style ??= Style::default();
 
         try {
             $index = $position->toIndex($this->area);
-        } catch (OutOfBoundsException $e) {
+        } catch (OutOfBoundsException) {
             return $position;
         }
         $chars = mb_str_split($line, 1);

--- a/src/Model/Display/BufferUpdates.php
+++ b/src/Model/Display/BufferUpdates.php
@@ -42,7 +42,7 @@ final class BufferUpdates implements Countable, IteratorAggregate
 
     public function last(): BufferUpdate
     {
-        if (count($this->updates) === 0) {
+        if ($this->updates === []) {
             throw new RuntimeException(
                 'Cannot get last update because there are no updates'
             );

--- a/src/Model/Display/Cell.php
+++ b/src/Model/Display/Cell.php
@@ -8,8 +8,9 @@ use PhpTui\Tui\Model\Color;
 use PhpTui\Tui\Model\Color\AnsiColor;
 use PhpTui\Tui\Model\Modifier;
 use PhpTui\Tui\Model\Style;
+use Stringable;
 
-final class Cell
+final class Cell implements Stringable
 {
     public function __construct(
         public string $char,

--- a/src/Model/Display/Display.php
+++ b/src/Model/Display/Display.php
@@ -18,16 +18,16 @@ final class Display
      * @param array<int,Buffer> $buffers
      */
     public function __construct(
-        private Backend $backend,
+        private readonly Backend $backend,
         private array $buffers,
         private int $current,
         /** @phpstan-ignore-next-line */
-        private bool $hiddenCursor,
-        private Viewport $viewport,
+        private readonly bool $hiddenCursor,
+        private readonly Viewport $viewport,
         private Area $viewportArea,
         private Area $lastKnownSize,
         private Position $lastKnownCursorPosition,
-        private WidgetRenderer $widgetRenderer,
+        private readonly WidgetRenderer $widgetRenderer,
     ) {
     }
 

--- a/src/Model/Layout/Layout.php
+++ b/src/Model/Layout/Layout.php
@@ -16,7 +16,7 @@ final class Layout
      * @param Constraint[] $constraints
      */
     private function __construct(
-        private ConstraintSolver $solver,
+        private readonly ConstraintSolver $solver,
         public Direction $direction,
         public Margin $margin,
         public array $constraints,

--- a/src/Model/LineComposer/LineTruncator.php
+++ b/src/Model/LineComposer/LineTruncator.php
@@ -81,7 +81,7 @@ class LineTruncator implements LineComposer
         }
 
         if ($styledGrapheme->symbolWidth() > $horizontalOffset) {
-            $symbol = self::trimOffset($styledGrapheme->symbol, $horizontalOffset);
+            $symbol = $this->trimOffset($styledGrapheme->symbol, $horizontalOffset);
             $horizontalOffset = 0;
 
             return $symbol;
@@ -91,7 +91,7 @@ class LineTruncator implements LineComposer
         return '';
     }
 
-    private static function trimOffset(string $string, int $horizontalOffset): string
+    private function trimOffset(string $string, int $horizontalOffset): string
     {
         return mb_substr($string, 0, $horizontalOffset);
     }

--- a/src/Model/LineComposer/LineTruncator.php
+++ b/src/Model/LineComposer/LineTruncator.php
@@ -15,8 +15,8 @@ class LineTruncator implements LineComposer
      * @param list<array{list<StyledGrapheme>,HorizontalAlignment}> $lines
      */
     public function __construct(
-        private array $lines,
-        private int $maxLineWidth,
+        private readonly array $lines,
+        private readonly int $maxLineWidth,
         private int $horizontalOffset = 0,
     ) {
     }

--- a/src/Model/Text/Line.php
+++ b/src/Model/Text/Line.php
@@ -31,14 +31,14 @@ final class Line implements IteratorAggregate, Stringable, Styleable
 
     public function __toString(): string
     {
-        return implode('', array_map(fn (Span $span) => $span->__toString(), $this->spans));
+        return implode('', array_map(static fn (Span $span): string => $span->__toString(), $this->spans));
     }
 
     public function width(): int
     {
         return array_sum(
             array_map(
-                fn (Span $span) => $span->width(),
+                static fn (Span $span): int => $span->width(),
                 $this->spans
             )
         );

--- a/src/Model/Text/Span.php
+++ b/src/Model/Text/Span.php
@@ -44,7 +44,7 @@ final class Span implements Stringable, Styleable
      */
     public function toStyledGraphemes(Style $baseStyle): array
     {
-        return array_map(function (string $grapheme) use ($baseStyle) {
+        return array_map(function (string $grapheme) use ($baseStyle): StyledGrapheme {
             return new StyledGrapheme(
                 symbol: $grapheme,
                 style: $baseStyle->patch($this->style),

--- a/src/Model/Text/Text.php
+++ b/src/Model/Text/Text.php
@@ -21,7 +21,7 @@ final class Text implements Styleable
 
     public static function fromString(string $string): self
     {
-        return new self(array_map(function (string $line) {
+        return new self(array_map(function (string $line): Line {
             return Line::fromString($line);
         }, explode("\n", $string)));
     }
@@ -30,12 +30,12 @@ final class Text implements Styleable
     {
         $placeholder = '{{1162128a-269a-4c09-88be-effc70a62a3a}}';
 
-        $string = preg_replace_callback('/<[^>]+>.*?<\/>/s', function ($matches) use ($placeholder) {
+        $string = preg_replace_callback('/<[^>]+>.*?<\/>/s', function (array $matches) use ($placeholder): string {
             return str_replace("\n", $placeholder, $matches[0]);
         }, $string);
 
         // We can only break into new lines at the breaks that are outside of tags.
-        $lines = array_map(function (string $line) use ($placeholder) {
+        $lines = array_map(function (string $line) use ($placeholder): Line {
             return Line::parse(str_replace($placeholder, "\n", $line));
         }, explode("\n", $string ?? ''));
 

--- a/src/Model/Widget/CanvasRenderer.php
+++ b/src/Model/Widget/CanvasRenderer.php
@@ -15,7 +15,7 @@ use PhpTui\Tui\Model\WidgetRenderer;
 
 final class CanvasRenderer implements WidgetRenderer
 {
-    public function __construct(private ShapePainter $painter)
+    public function __construct(private readonly ShapePainter $painter)
     {
     }
 

--- a/src/Model/WidgetRenderer/AggregateWidgetRenderer.php
+++ b/src/Model/WidgetRenderer/AggregateWidgetRenderer.php
@@ -21,7 +21,7 @@ class AggregateWidgetRenderer implements WidgetRenderer
     /**
      * @param WidgetRenderer[] $renderers
      */
-    public function __construct(private array $renderers)
+    public function __construct(private readonly array $renderers)
     {
     }
 

--- a/src/Model/WidgetRenderer/CachingWidgetRenderer.php
+++ b/src/Model/WidgetRenderer/CachingWidgetRenderer.php
@@ -11,16 +11,13 @@ use PhpTui\Tui\Model\WidgetRenderer;
 
 final class CachingWidgetRenderer implements WidgetRenderer
 {
-    private WidgetRenderer $innerRenderer;
-
     /**
      * @var array<string,Buffer>
      */
     private array $cache = [];
 
-    public function __construct(WidgetRenderer $inner)
+    public function __construct(private readonly WidgetRenderer $innerRenderer)
     {
-        $this->innerRenderer = $inner;
     }
 
     public function render(WidgetRenderer $renderer, Widget $widget, Buffer $buffer): void

--- a/tests/Benchmark/Extension/Core/Widget/CanvasBench.php
+++ b/tests/Benchmark/Extension/Core/Widget/CanvasBench.php
@@ -24,9 +24,9 @@ use PhpTui\Tui\Model\Display\Display;
 #[Revs(25)]
 final class CanvasBench
 {
-    private Display $display;
+    private readonly Display $display;
 
-    private StringPainter $painter;
+    private readonly StringPainter $painter;
 
     public function __construct()
     {

--- a/tests/Benchmark/Extension/ImageMagick/ImageShapeBench.php
+++ b/tests/Benchmark/Extension/ImageMagick/ImageShapeBench.php
@@ -22,9 +22,9 @@ use PhpTui\Tui\Model\Display\Display;
 #[Revs(25)]
 final class ImageShapeBench
 {
-    private Display $display;
+    private readonly Display $display;
 
-    private StringPainter $painter;
+    private readonly StringPainter $painter;
 
     public function __construct()
     {

--- a/tests/Benchmark/Model/DisplayBench.php
+++ b/tests/Benchmark/Model/DisplayBench.php
@@ -41,9 +41,9 @@ use PhpTui\Tui\Model\Widget\Borders;
 
 final class DisplayBench
 {
-    private Display $display;
+    private readonly Display $display;
 
-    private StringPainter $painter;
+    private readonly StringPainter $painter;
 
     public function __construct()
     {

--- a/tests/Example/DemoTest.php
+++ b/tests/Example/DemoTest.php
@@ -49,7 +49,7 @@ class DemoTest extends TestCase
 
     public function testList(): void
     {
-        srand(0);
+        mt_srand(0);
         $backend = $this->execute(
             CharKeyEvent::new('4'),
             null,
@@ -60,7 +60,7 @@ class DemoTest extends TestCase
 
     public function testTable(): void
     {
-        srand(0);
+        mt_srand(0);
         $backend = $this->execute(
             CharKeyEvent::new('5'),
             null,
@@ -84,7 +84,7 @@ class DemoTest extends TestCase
         if (!extension_loaded('imagick')) {
             self::markTestSkipped('imagick not loaded');
         }
-        srand(0);
+        mt_srand(0);
         $backend = $this->execute(
             CharKeyEvent::new('7'),
             null,
@@ -105,7 +105,7 @@ class DemoTest extends TestCase
 
     public function testGauge(): void
     {
-        srand(0);
+        mt_srand(0);
         $backend = $this->execute(
             CharKeyEvent::new('!'),
             null,
@@ -116,7 +116,7 @@ class DemoTest extends TestCase
 
     public function testBarChart(): void
     {
-        srand(0);
+        mt_srand(0);
         $backend = $this->execute(
             CharKeyEvent::new('"'),
             null,

--- a/tests/Example/DocsTest.php
+++ b/tests/Example/DocsTest.php
@@ -13,8 +13,8 @@ use RuntimeException;
 
 class DocsTest extends TestCase
 {
-    public const WIDTH = 20;
-    public const HEIGHT = 50;
+    final public const WIDTH = 20;
+    final public const HEIGHT = 50;
 
     /**
      * @dataProvider provideExamples

--- a/tests/Example/DocsTest.php
+++ b/tests/Example/DocsTest.php
@@ -38,9 +38,7 @@ class DocsTest extends TestCase
             ],
         );
         if (!is_resource($process)) {
-            throw new RuntimeException(sprintf(
-                'Could not spawn process'
-            ));
+            throw new RuntimeException('Could not spawn process');
         }
         $output = (string)stream_get_contents($pipes[1]);
         $exitCode = proc_close($process);

--- a/tests/Example/DocsTest.php
+++ b/tests/Example/DocsTest.php
@@ -56,7 +56,7 @@ class DocsTest extends TestCase
         $painter->paint($actions);
         $output = $painter->toString();
 
-        $this->assertSnapshot($path, $output, 'html', self::normalize(...));
+        $this->assertSnapshot($path, $output, 'html', $this->normalize(...));
     }
 
     /**
@@ -95,7 +95,7 @@ class DocsTest extends TestCase
 
     }
 
-    private static function normalize(string $string): string
+    private function normalize(string $string): string
     {
         $normalized = preg_replace('{canvas id=".*?"}', 'canvas id="***"', $string);
         $normalized = preg_replace('{getElementById\(".*?"\)}', 'getElementById("***")', (string)$normalized);

--- a/tests/Unit/Bridge/PhpTerm/PhpTermBackendTest.php
+++ b/tests/Unit/Bridge/PhpTerm/PhpTermBackendTest.php
@@ -82,7 +82,7 @@ class PhpTermBackendTest extends TestCase
             'SetForegroundColor(Reset)',
             'SetBackgroundColor(Reset)',
             'Reset()',
-        ], array_map(fn (Action $action) => $action->__toString(), $buffer->actions()));
+        ], array_map(static fn (Action $action): string => $action->__toString(), $buffer->actions()));
     }
 
     public function testDoesNotMoveCursorUnnecessarily(): void
@@ -112,7 +112,7 @@ class PhpTermBackendTest extends TestCase
             'SetForegroundColor(Reset)',
             'SetBackgroundColor(Reset)',
             'Reset()',
-        ], array_map(fn (Action $action) => $action->__toString(), $buffer->actions()));
+        ], array_map(static fn (Action $action): string => $action->__toString(), $buffer->actions()));
     }
 
     public function testDoesNotChangeColorUnnecessarily(): void
@@ -137,7 +137,7 @@ class PhpTermBackendTest extends TestCase
             'SetForegroundColor(Reset)',
             'SetBackgroundColor(Reset)',
             'Reset()',
-        ], array_map(fn (Action $action) => $action->__toString(), $buffer->actions()));
+        ], array_map(static fn (Action $action): string => $action->__toString(), $buffer->actions()));
     }
 
     public function testModifiersReset(): void
@@ -189,7 +189,7 @@ class PhpTermBackendTest extends TestCase
             'SetForegroundColor(Reset)',
             'SetBackgroundColor(Reset)',
             'Reset()',
-        ], array_map(fn (Action $action) => $action->__toString(), $buffer->actions()));
+        ], array_map(static fn (Action $action): string => $action->__toString(), $buffer->actions()));
     }
 
     private function draw(BufferPainter $buffer, BufferUpdates $updates): void

--- a/tests/Unit/Extension/Core/Widget/ChartWidgetTest.php
+++ b/tests/Unit/Extension/Core/Widget/ChartWidgetTest.php
@@ -132,7 +132,7 @@ class ChartWidgetTest extends WidgetTestCase
                     ->marker(Marker::Dot)
                     ->style(Style::default()->fg(AnsiColor::Green))
                     ->data(
-                        array_map(function (int $x, int $y) {
+                        array_map(function (int $x, int $y): array {
                             return [$x, $y];
                         }, range(0, 7), [0, 1, 2, 1, 0, -1, -2, -1])
                     )
@@ -202,7 +202,7 @@ class ChartWidgetTest extends WidgetTestCase
      */
     private function series(int ...$points): array
     {
-        return array_map(function (int $x, int $y) {
+        return array_map(function (int $x, int $y): array {
             return [$x, $y];
         }, range(0, count($points) - 1), $points);
     }

--- a/tests/Unit/Model/Layout/LayoutTest.php
+++ b/tests/Unit/Model/Layout/LayoutTest.php
@@ -28,7 +28,7 @@ class LayoutTest extends TestCase
             $target->height,
             array_sum(
                 array_map(
-                    fn (Area $area) => $area->height,
+                    static fn (Area $area): int => $area->height,
                     $chunks->toArray()
                 )
             )

--- a/tests/Unit/Model/StyleableTest.php
+++ b/tests/Unit/Model/StyleableTest.php
@@ -44,11 +44,13 @@ class StyleableTest extends TestCase
      */
     public function testFgColors(AnsiColor $color, string $colorName): void
     {
+        $methodName = lcfirst($colorName);
+
         /**
          * @var Span $span
          * @phpstan-ignore-next-line
          */
-        $span = Span::fromString('Hello')->{lcfirst($colorName)}();
+        $span = Span::fromString('Hello')->$methodName();
         self::assertSame($color, $span->style->fg);
     }
 
@@ -57,11 +59,13 @@ class StyleableTest extends TestCase
      */
     public function testBgColors(AnsiColor $color, string $colorName): void
     {
+        $methodName = sprintf('on%s', $colorName);
+
         /**
          * @var Span $span
          * @phpstan-ignore-next-line
          */
-        $span = Span::fromString('Hello')->{"on{$colorName}"}();
+        $span = Span::fromString('Hello')->$methodName();
         self::assertSame($color, $span->style->bg);
     }
 

--- a/tests/Unit/Model/StyleableTest.php
+++ b/tests/Unit/Model/StyleableTest.php
@@ -89,8 +89,8 @@ class StyleableTest extends TestCase
     public static function colorProvider(): array
     {
         return array_map(
-            fn (AnsiColor $color) => [$color, $color->name],
-            array_filter(AnsiColor::cases(), fn (AnsiColor $color) => $color !== AnsiColor::Reset)
+            static fn (AnsiColor $color): array => [$color, $color->name],
+            array_filter(AnsiColor::cases(), static fn (AnsiColor $color): bool => $color !== AnsiColor::Reset)
         );
     }
 }

--- a/tests/Unit/Model/Text/SpanParserTest.php
+++ b/tests/Unit/Model/Text/SpanParserTest.php
@@ -268,7 +268,7 @@ class SpanParserTest extends TestCase
         $text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
                         sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
 
-        $spans = SpanParser::new()->parse("<fg=green>{$text}</>");
+        $spans = SpanParser::new()->parse(sprintf('<fg=green>%s</>', $text));
         self::assertCount(1, $spans);
 
         $firstSpan = $spans[0];


### PR DESCRIPTION
Reference: https://github.com/rectorphp/rector

Rector offers some excellent rules, though some can be annoying (we can disable those as needed). Our current configuration is located in `rector.php`.

Some notable rules:

- `StaticArrowFunctionRector::class` => Adds `static` to closures that don't access the object context.
- `EncapsedStringsToSprintfRector::class` => Changes `"{foo}"` to `sprintf(...)`
- `UnwrapSprintfOneArgumentRector::class` => Changes `sprintf('Foo')` to `'foo'`
- `TYPE_DECLARATION` => Adds missing return types and so on.

The skipped rules can always be revisited whenever you want: `$rectorConfig->skip([ ...`