### PR TITLE
Fix: accepts both `;` and blank space as separators when parsing a span

### DIFF
--- a/src/Model/Text/SpanParser.php
+++ b/src/Model/Text/SpanParser.php
@@ -78,8 +78,12 @@ final class SpanParser
     private function createStyleFromTag(string $tag, array &$styleStack): Style
     {
         $style = Style::default();
+        $attributes = preg_split('/[; ]/', $tag);
 
-        $attributes = explode(';', $tag);
+        if ($attributes === false) {
+            return $style;
+        }
+
         foreach ($attributes as $attribute) {
             $attribute = explode('=', $attribute);
             [$key, $value] = [

--- a/tests/Unit/Model/Text/SpanParserTest.php
+++ b/tests/Unit/Model/Text/SpanParserTest.php
@@ -276,10 +276,34 @@ class SpanParserTest extends TestCase
         self::assertSame(AnsiColor::Green, $firstSpan->style->fg);
     }
 
-    public function testUsingWrongSeparator(): void
+    public function testUsingOnlySpaceAsSeparator(): void
     {
-        $this->expectException(InvalidArgumentException::class);
         $spans = SpanParser::new()->parse('<fg=white bg=red>Hello</> World');
+        self::assertCount(2, $spans);
+
+        $firstSpan = $spans[0];
+        self::assertSame('Hello', $firstSpan->content);
+        self::assertSame(AnsiColor::White, $firstSpan->style->fg);
+        self::assertSame(AnsiColor::Red, $firstSpan->style->bg);
+    }
+
+    public function testMixingSpaceAndSemicolonAsSeparator(): void
+    {
+        $spans = SpanParser::new()->parse('<fg=white bg=red;options=bold,italic>Hello</> World');
+        self::assertCount(2, $spans);
+
+        $firstSpan = $spans[0];
+        self::assertSame('Hello', $firstSpan->content);
+        self::assertSame(AnsiColor::White, $firstSpan->style->fg);
+        self::assertSame(AnsiColor::Red, $firstSpan->style->bg);
+        self::assertTrue(($firstSpan->style->addModifiers & Modifier::BOLD) === Modifier::BOLD);
+        self::assertTrue(($firstSpan->style->addModifiers & Modifier::ITALIC) === Modifier::ITALIC);
+
+    }
+
+    public function testParseAttributesFlexibilityWithSeparators(): void
+    {
+        $spans = SpanParser::new()->parse('<fg=white   bg=red ;  options=bold,italic>Hello</> World');
         self::assertCount(2, $spans);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/php-tui/php-tui/issues/145

@dantleech What do you think? Since we're a subset, we can be a bit more flexible in this part ...