### PR TITLE
Accept solid backgrounds on gauges

### DIFF
--- a/src/Extension/Core/Widget/GaugeRenderer.php
+++ b/src/Extension/Core/Widget/GaugeRenderer.php
@@ -7,6 +7,7 @@ namespace PhpTui\Tui\Extension\Core\Widget;
 use PhpTui\Tui\Model\Display\Buffer;
 use PhpTui\Tui\Model\Position\FractionalPosition;
 use PhpTui\Tui\Model\Position\Position;
+use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Symbol\BlockSet;
 use PhpTui\Tui\Model\Text\Span;
 use PhpTui\Tui\Model\Widget;
@@ -20,48 +21,57 @@ final class GaugeRenderer implements WidgetRenderer
         Buffer $buffer
     ): void {
         $area = $buffer->area();
-        if (!$widget instanceof GaugeWidget) {
+        if (!$widget instanceof GaugeWidget || $area->height < 1) {
             return;
         }
 
         $buffer->setStyle($area, $widget->style);
-        if ($area->height < 1) {
-            return;
-        }
-
-        $pct = round($widget->ratio * 100);
-        $label = $widget->label ?? Span::fromString(sprintf('%.2f%%', $pct));
+        $label = $widget->label ?? Span::fromString(sprintf('%.2f%%', round($widget->ratio * 100)));
         $clampedLabelWidth = min($area->width, $label->width());
-        $labelCol = (int)floor($area->left() + ($area->width - $clampedLabelWidth) / 2);
         $labelRow = (int)floor($area->top() + $area->height / 2);
+        $labelCol = (int)floor($area->left() + ($area->width - $clampedLabelWidth) / 2);
 
         $filledWidth = $area->width * $widget->ratio;
-        $end = $area->left() + floor($filledWidth);
+        $end = (int) ($area->left() + floor($filledWidth));
 
         foreach (range($area->top(), $area->bottom() - 1) as $y) {
-            foreach (range($area->left(), (int)floor($end)) as $x) {
-
+            foreach (range($area->left(), $area->right() - 1) as $x) {
                 if ($x === $area->right()) {
                     break;
                 }
                 $cell = $buffer->get(Position::at($x, $y));
-                if ($x < $labelCol || $x > $labelCol + $clampedLabelWidth - 1 || $y != $labelRow) {
+
+                // Determine if the cell is part of the empty portion of the gauge
+                $isEmptyPortion = $x > $end;
+                // Determine if the cell is part of the label
+                $isLabelArea = $x >= $labelCol && $x < ($labelCol + $clampedLabelWidth) && $y === $labelRow;
+
+                if ($isEmptyPortion) {
+                    // Draw the empty portion of the gauge only if the widget has a background color
+                    if (!$isLabelArea && $widget->style->bg !== null) {
+                        $cell->setChar(BlockSet::FULL);
+                        $cell->setStyle(Style::default()->fg($widget->style->bg));
+                    }
+                } elseif (!$isLabelArea) {
+                    // Draw the filled portion of the gauge
                     $cell->setChar(BlockSet::FULL);
                     $cell->setStyle($widget->style->atPosition(FractionalPosition::at(
                         ($x - $area->left()) / $area->width,
                         ($y - $area->top()) / $area->height,
                     )));
                 } else {
+                    // Spaces for the part that is covered by the label
                     $cell->setChar(' ');
                 }
             }
 
-            if ($widget->ratio < 1) {
-                $buffer->get(
-                    Position::at((int)floor($end), $y)
-                )->setChar($this->getUnicodeBlock(fmod($filledWidth, 1.0)));
+            // Draw a "partially filled cell" if the ratio is not a whole number
+            if ($widget->ratio < 1.0) {
+                $buffer->get(Position::at($end, $y))
+                    ->setChar($this->getUnicodeBlock(fmod($filledWidth, 1.0)));
             }
         }
+
         $buffer->putSpan(Position::at($labelCol, $labelRow), $label, $clampedLabelWidth);
     }
 

--- a/tests/Unit/Extension/Core/Widget/GaugeRendererTest.php
+++ b/tests/Unit/Extension/Core/Widget/GaugeRendererTest.php
@@ -8,6 +8,7 @@ use Generator;
 use PhpTui\Tui\Extension\Core\Widget\GaugeWidget;
 use PhpTui\Tui\Model\Area;
 use PhpTui\Tui\Model\Display\Buffer;
+use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Text\Span;
 use PhpTui\Tui\Model\Widget;
 
@@ -75,6 +76,26 @@ class GaugeRendererTest extends WidgetTestCase
                 '██████████',
             ]
            ,
+        ];
+        yield 'solid gauge 75' => [
+            Area::fromDimensions(10, 4),
+            GaugeWidget::default()->ratio(0.75)->style(Style::default()->red()->onLightRed()),
+            [
+                '███████▌██',
+                '███████▌██',
+                '██75.00%██',
+                '███████▌██',
+            ],
+        ];
+        yield 'solid gauge 18' => [
+            Area::fromDimensions(10, 4),
+            GaugeWidget::default()->ratio(0.18)->style(Style::default()->red()->onLightRed()),
+            [
+                '█▊████████',
+                '█▊████████',
+                '█▊18.00%██',
+                '█▊████████',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Before this change, these gauges:

```php
GaugeWidget::default()->ratio(0.25)->style(Style::default()->yellow()->onLightYellow()),

GaugeWidget::default()->ratio(0.63)->style(Style::default()->blue()->onLightBlue()),

GaugeWidget::default()->ratio(0.30)->style(Style::default()->green()->onLightGreen())->label(
    Span::fromString(sprintf('%.2f%%', 34))->style(Style::default()->black())
),

GaugeWidget::default()->ratio(0.92)->style(Style::default()->red()->onLightRed())->label(
    Span::fromString(sprintf('%.2f%%', 92))->style(Style::default()->white()->onYellow())
),
```

Were rendered this way:

![image](https://github.com/php-tui/php-tui/assets/999232/d469e5f1-a6b1-41bb-b62a-3256ec9d3920)

After:

![image](https://github.com/php-tui/php-tui/assets/999232/963cf270-02d5-44ed-b548-f8393a67fb32)

But I'm not sure if this is the desired behavior... I still haven't mastered the whole picture of the project, including how things are supposed to work, etc.

Also, it's not 100% related to this PR, but I found a strange bug caused by this `continue` here: https://github.com/php-tui/php-tui/blob/main/src/Model/Display/Buffer.php#L249

I'll create an issue about it later.


