### PR TITLE
Fix multibyte issues with `parse()`

### DIFF
--- a/example/demo/src/Page/EventsPage.php
+++ b/example/demo/src/Page/EventsPage.php
@@ -14,7 +14,6 @@ use PhpTui\Tui\Extension\Core\Widget\ListWidget;
 use PhpTui\Tui\Extension\Core\Widget\ParagraphWidget;
 use PhpTui\Tui\Model\Layout\Constraint;
 use PhpTui\Tui\Model\Text\Line;
-use PhpTui\Tui\Model\Text\Span;
 use PhpTui\Tui\Model\Text\Text;
 use PhpTui\Tui\Model\Text\Title;
 use PhpTui\Tui\Model\Widget;
@@ -37,11 +36,7 @@ final class EventsPage implements Component
                     ->padding(Padding::left(1))
                     ->widget(
                         ParagraphWidget::fromLines(
-                            Line::fromSpans([
-                                Span::fromString('Welcome to the '),
-                                Span::fromString('PHP-TUI 🐘')->bold(),
-                                Span::fromString(' demo application.'),
-                            ]),
+                            Line::parse('Welcome to the <fg=white;options=bold>PHP-TUI 🐘</> demo application.'),
                             Line::parse('Use the <fg=#ffa500>tab</> to go to the next page and <fg=#ffa500>shift-tab</> to go to the previous page.'),
                             Line::parse('<fg=white>Below you can see a log of all the input events, try moving the mouse!</> 🐭'),
                         ),

--- a/src/Model/Text/SpanParser.php
+++ b/src/Model/Text/SpanParser.php
@@ -44,12 +44,12 @@ final class SpanParser
                 continue;
             }
 
-            $textBeforeTag = mb_substr($input, $offset, $pos - $offset);
+            $textBeforeTag = substr($input, $offset, $pos - $offset);
             if ($textBeforeTag !== '') {
                 $spans[] = $this->createSpan($textBeforeTag, $styleStack);
             }
 
-            $offset = $pos + mb_strlen($tag);
+            $offset = $pos + strlen($tag);
 
             $isOpeningTag = $tag[1] !== '/';
             if ($isOpeningTag) {
@@ -60,8 +60,8 @@ final class SpanParser
             }
         }
 
-        if ($offset < mb_strlen($input)) {
-            $spans[] = $this->createSpan(mb_substr($input, $offset), $styleStack);
+        if ($offset < strlen($input)) {
+            $spans[] = $this->createSpan(substr($input, $offset), $styleStack);
         }
 
         return $spans;

--- a/tests/Unit/Model/Text/SpanParserTest.php
+++ b/tests/Unit/Model/Text/SpanParserTest.php
@@ -282,4 +282,34 @@ final class SpanParserTest extends TestCase
         $spans = SpanParser::new()->parse('<fg=white bg=red>Hello</> World');
         self::assertCount(2, $spans);
     }
+
+    public function testMultiWidthCharacters(): void
+    {
+        $spans = SpanParser::new()->parse('<fg=green>Hello 你好 PHP 🐘<fg=white>PHP 🐘 Hello 你好</></>');
+        self::assertCount(2, $spans);
+
+        $firstSpan = $spans[0];
+        self::assertSame('Hello 你好 PHP 🐘', $firstSpan->content);
+        self::assertSame(AnsiColor::Green, $firstSpan->style->fg);
+
+        $secondSpan = $spans[1];
+        self::assertSame('PHP 🐘 Hello 你好', $secondSpan->content);
+        self::assertSame(AnsiColor::White, $secondSpan->style->fg);
+
+        $spans = SpanParser::new()->parse('Welcome to the <fg=white;options=bold>PHP-TUI 🐘</> demo application.');
+        self::assertCount(3, $spans);
+
+        $firstSpan = $spans[0];
+        self::assertSame('Welcome to the ', $firstSpan->content);
+        self::assertNull($firstSpan->style->fg);
+
+        $secondSpan = $spans[1];
+        self::assertSame('PHP-TUI 🐘', $secondSpan->content);
+        self::assertSame(AnsiColor::White, $secondSpan->style->fg);
+        self::assertTrue(($secondSpan->style->addModifiers & Modifier::BOLD) === Modifier::BOLD);
+
+        $thirdSpan = $spans[2];
+        self::assertSame(' demo application.', $thirdSpan->content);
+        self::assertNull($thirdSpan->style->fg);
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/php-tui/php-tui/issues/190

In the `preg_match_all()` with `PREG_OFFSET_CAPTURE`, the `offset` is determined using `strlen()` instead of `mb_strlen()`. So, when finding the word `你好`, it returns `6` instead of `2`.

Simply switching from `mb_substr` to `substr` fix the issue.

Additionally, I've opted not to use `mb_strlen()` if not necessary, like `mb_strlen($tag)`, where `$tag` is guaranteed not to be a multibyte string.
