### PR TITLE
Improve the gauge label style when filled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+## master
+
+Improvements:
+
+- Improve the gauge label style when filled #195 @KennedyTedesco
+
 ## 0.1.0
 
 Features:

--- a/src/Bridge/PhpTerm/PhpTermBackend.php
+++ b/src/Bridge/PhpTerm/PhpTermBackend.php
@@ -258,6 +258,11 @@ final class PhpTermBackend implements Backend
             return new SetRgbBackgroundColor($color->r, $color->g, $color->b);
         }
 
+        // if we have a raw gradient, use it's first stop.
+        if ($color instanceof LinearGradient) {
+            return $this->setForegroundColor($color->at(FractionalPosition::at(0, 0)));
+        }
+
         throw new RuntimeException(sprintf('Do not know how to set color of type "%s"', $color::class));
     }
 }

--- a/src/Extension/Core/Widget/GaugeRenderer.php
+++ b/src/Extension/Core/Widget/GaugeRenderer.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PhpTui\Tui\Extension\Core\Widget;
 
+use PhpTui\Tui\Model\Color\AnsiColor;
 use PhpTui\Tui\Model\Display\Buffer;
 use PhpTui\Tui\Model\Position\FractionalPosition;
 use PhpTui\Tui\Model\Position\Position;
+use PhpTui\Tui\Model\Style;
 use PhpTui\Tui\Model\Symbol\BlockSet;
 use PhpTui\Tui\Model\Text\Span;
 use PhpTui\Tui\Model\Widget;
@@ -53,6 +55,11 @@ final class GaugeRenderer implements WidgetRenderer
                     )));
                 } else {
                     $cell->setChar(' ');
+                    $cell->setStyle(
+                        Style::default()
+                            ->bg($widget->style->fg ?? AnsiColor::Reset)
+                            ->fg($widget->style->bg ?? AnsiColor::Reset),
+                    );
                 }
             }
 


### PR DESCRIPTION
```php
GaugeWidget::default()->ratio(0.43)->style(Style::default()->green()->onLightGreen()),
GaugeWidget::default()->ratio(0.63)->style(Style::default()->blue()->onLightBlue()),
```

Currently:

![image](https://github.com/php-tui/php-tui/assets/999232/f23cc760-6b22-40e3-944c-0d022f5ce125)

After:

![image](https://github.com/php-tui/php-tui/assets/999232/3c4f30ef-0cbf-4561-85e4-84667b2fb804)

This puts us in sync with Ratatuti's behavior.