### PR TITLE
Add PHP 8.3 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
                 php-version:
                     - '8.1'
                     - '8.2'
+                    - '8.3'
 
         steps:
             -
@@ -51,7 +52,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '8.1'
+                    - '8.3'
 
         steps:
             -
@@ -82,7 +83,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '8.1'
+                    - '8.3'
         steps:
             -
                 name: "Checkout code"
@@ -112,7 +113,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '8.1'
+                    - '8.3'
         steps:
             -
                 name: "Checkout code"


### PR DESCRIPTION
I also think it's fine to use PHP 8.3 by default when running PHPBench, PHPStan, and PHPCSFixer. What you think?