### PR TITLE
Perf: improves `Position::toIndex()`

### DIFF
--- a/src/Position/Position.php
+++ b/src/Position/Position.php
@@ -43,9 +43,7 @@ final class Position implements Stringable
     public static function fromIndex(int $i, Area $area): self
     {
         if (
-            false === (
-                $i < $area->area()
-            )
+            $i >= ($area->width * $area->height) // index >= area size
         ) {
             throw new OutOfBoundsException(sprintf(
                 'Index %d outside of area %s',
@@ -63,12 +61,10 @@ final class Position implements Stringable
     public function toIndex(Area $area): int
     {
         if (
-            false === (
-                $this->x >= $area->left()
-                && $this->x < $area->right()
-                && $this->y >= $area->top()
-                && $this->y < $area->bottom()
-            )
+            $this->x < $area->position->x                       // x < area left
+            || $this->y < $area->position->y                    // y < area top
+            || $this->x >= ($area->position->x + $area->width)  // x >= area right
+            || $this->y >= ($area->position->y + $area->height) // y >= area bottom
         ) {
             throw new OutOfBoundsException(sprintf(
                 'Position %s outside of area %s when trying to get index',


### PR DESCRIPTION
**Pros:**

**Blackfire** shows `-18%` on cpu time when running `example/docs/widget/gridWidget.php`

![image](https://github.com/php-tui/php-tui/assets/999232/a46f28b0-448e-4e5f-8392-80d279a9db48)

![image](https://github.com/php-tui/php-tui/assets/999232/cdb82974-556f-4e5d-a6a9-ebf36dd3e8c5)

**Bench**:

```
benchRenderFrame........................I9 - [Mo18.842ms vs. Mo22.334ms] -15.64% (±0.88%)
benchImageShape.........................I3 - [Mo11.700ms vs. Mo12.682ms] -7.74% (±0.58%)
benchLowResolutionMap...................I9 - [Mo13.379ms vs. Mo14.530ms] -7.92% (±0.53%)
benchHighResolutionMap..................I9 - [Mo17.505ms vs. Mo18.747ms] -6.63% (±0.36%)
```

**Cons:**

Less legible to read? I've tried to mitigate that by adding comments. It's a tradeoff.