### PR TITLE
Fix issue when truncating unicode text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Refactoring:
 Bug fixes:
 
 - Fix block adjacent border renderering #201
-- Fix `StyledGrapheme` symbol width #214
+- Fix `StyledGrapheme` symbol width #214 @KennedyTedesco
+- Fix issue when truncating unicode text #215 @KennedyTedesco
 
 ## 0.1.0
 

--- a/src/Text/LineComposer/LineTruncator.php
+++ b/src/Text/LineComposer/LineTruncator.php
@@ -61,7 +61,7 @@ final class LineTruncator implements LineComposer
                 );
 
                 $currentLine[] = new StyledGrapheme($symbol, $styledGrapheme->style);
-                $currentLineWidth += mb_strlen($symbol);
+                $currentLineWidth += mb_strwidth($symbol);
             }
             yield [
                 $currentLine,

--- a/tests/Unit/Extension/Core/Widget/ParagraphRendererTest.php
+++ b/tests/Unit/Extension/Core/Widget/ParagraphRendererTest.php
@@ -35,6 +35,7 @@ final class ParagraphRendererTest extends WidgetTestCase
             'Goodbye   ',
         ], $buffer->toLines());
     }
+
     /**
      * @dataProvider provideParagraph
      */
@@ -46,8 +47,8 @@ final class ParagraphRendererTest extends WidgetTestCase
         $buffer = Buffer::empty($area);
         $this->render($buffer, $paragraph);
         self::assertEquals($expected, $buffer->toString());
-
     }
+
     /**
      * @return Generator<string,array{Area,ParagraphWidget,string}>
      */
@@ -84,6 +85,13 @@ final class ParagraphRendererTest extends WidgetTestCase
             ),
             '1/1       ',
             '     About',
+        ];
+        yield 'unicode' => [
+            Area::fromDimensions(14, 1),
+            ParagraphWidget::fromText(
+                Text::fromString('こんにちは, 世界! 😃')
+            ),
+            'こんにちは, 世',
         ];
     }
 }


### PR DESCRIPTION
Previously, an `OutOfBoundsException` was thrown for this same test.

```
1) PhpTui\Tui\Tests\Unit\Extension\Core\Widget\ParagraphRendererTest::testParagraph with data set "unicode"
OutOfBoundsException: Position (14,0) outside of area @(0,0) of 14x1 when trying to get index
```