### PR TITLE
POC Add method to set inline height

### DIFF
--- a/src/Display/Display.php
+++ b/src/Display/Display.php
@@ -102,6 +102,25 @@ final class Display
     }
 
     /**
+     * Set the height of an inline viewport. If the current viewport is not inline
+ * this has no effect.
+     * @param int<0,max> $height
+     */
+    public function setInlineHeight(int $height): void
+    {
+        if (!$this->viewport instanceof Inline) {
+            return;
+        }
+
+        if ($height === $this->viewportArea->height) {
+            return;
+        }
+
+        $this->viewport->height = $height;
+        $this->resize($this->lastKnownSize);
+    }
+
+    /**
      * Render a widget before the current inline viewport. This has no effect when the
      * viewport is fullscreen.
      *

--- a/src/Display/Viewport/Inline.php
+++ b/src/Display/Viewport/Inline.php
@@ -23,7 +23,7 @@ final class Inline implements Viewport
          * Height of the viewport
          * @var int<0,max>
          */
-        public readonly int $height
+        public int $height
     ) {
     }
 


### PR DESCRIPTION
We've already ported Ratatuis  `insertBeforeViewport` which only works with the `inline` viewport, and is somewhat of a code smell. This PR adds an additional `setInlineHeight` method 