### PR TITLE
Add paragraph word wrap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## master
 
+Features:
+
+- Add paragraph word wrap support #219 @KennedyTedesco
+
 Improvements:
 
 - Improve the gauge label style when filled #195 @KennedyTedesco

--- a/docs/content/docs/reference/widgets/ParagraphWidget.md
+++ b/docs/content/docs/reference/widgets/ParagraphWidget.md
@@ -21,7 +21,7 @@ Configure the widget using the builder methods named as follows:
 | Name | Type | Description |
 | --- | --- | --- |
 | **style** | `PhpTui\Tui\Style\Style` |  |
-| **wrap** | `PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap\|null` |  |
+| **wrap** | `PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap` |  |
 | **text** | `PhpTui\Tui\Text\Text` |  |
 | **scroll** | `array` |  |
 | **alignment** | `PhpTui\Tui\Widget\HorizontalAlignment` |  |

--- a/example/demo/src/Page/BlocksPage.php
+++ b/example/demo/src/Page/BlocksPage.php
@@ -77,7 +77,7 @@ final class BlocksPage implements Component
 
         return ParagraphWidget::fromText(
             Text::parse(sprintf('<fg=darkgray>%s</>', $text))
-        )->wrap(Wrap::trimmed());
+        )->wrap(Wrap::Word);
     }
 
     /**

--- a/src/Extension/Core/Widget/Paragraph/Wrap.php
+++ b/src/Extension/Core/Widget/Paragraph/Wrap.php
@@ -4,14 +4,10 @@ declare(strict_types=1);
 
 namespace PhpTui\Tui\Extension\Core\Widget\Paragraph;
 
-final class Wrap
+enum Wrap
 {
-    private function __construct(public bool $trim)
-    {
-    }
-
-    public static function trimmed(): self
-    {
-        return new self(trim: true);
-    }
+    case None;
+    case Word;
+    case WordTrimmed;
+    case Character;
 }

--- a/src/Extension/Core/Widget/ParagraphWidget.php
+++ b/src/Extension/Core/Widget/ParagraphWidget.php
@@ -20,7 +20,7 @@ final class ParagraphWidget implements Widget
     /** @param array{int,int} $scroll */
     private function __construct(
         public Style $style,
-        public ?Wrap $wrap,
+        public Wrap $wrap,
         public Text $text,
         public array $scroll,
         public HorizontalAlignment $alignment
@@ -36,7 +36,7 @@ final class ParagraphWidget implements Widget
     {
         return new self(
             style: Style::default(),
-            wrap: null,
+            wrap: Wrap::None,
             text: $text,
             scroll: [0,0],
             alignment: HorizontalAlignment::Left,

--- a/src/Text/LineComposer/WordWrapper.php
+++ b/src/Text/LineComposer/WordWrapper.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpTui\Tui\Text\LineComposer;
+
+use Generator;
+use PhpTui\Tui\Text\LineComposer;
+use PhpTui\Tui\Text\StyledGrapheme;
+use PhpTui\Tui\Widget\HorizontalAlignment;
+
+final class WordWrapper implements LineComposer
+{
+    private const NBSP = "\u{00a0}";
+
+    /**
+     * @param list<array{list<StyledGrapheme>,HorizontalAlignment}> $lines
+     */
+    public function __construct(
+        private readonly array $lines,
+        private readonly int $maxLineWidth,
+        private readonly bool $trim = false,
+    ) {
+    }
+
+    public function nextLine(): Generator
+    {
+        if ($this->maxLineWidth === 0) {
+            return;
+        }
+
+        $wrappedLines = [];
+        foreach ($this->lines as $line) {
+            /**
+             * @var StyledGrapheme[] $lineSymbols
+             * @var HorizontalAlignment $lineAlignment
+             */
+            [$lineSymbols, $lineAlignment] = $line;
+            [$currentLine, $currentLineWidth] = [[], 0];
+            [$currentWord, $currentWordWidth] = [[], 0];
+            [$whitespaceBuffer, $whitespacesWidth] = [[], 0];
+            $hasSeenNonWhitespace = false;
+
+            foreach ($lineSymbols as $symbol) {
+                $isWhitespace = $this->isWhitespace($symbol);
+                $symbolWidth = $symbol->symbolWidth();
+                if ($symbolWidth > $this->maxLineWidth) {
+                    continue;
+                }
+
+                // Append finished word to current line
+                if (
+                    $hasSeenNonWhitespace && $isWhitespace
+                    // Append if trimmed (whitespaces removed) word would overflow
+                    || $this->trim && ($currentWordWidth + $symbolWidth) > $this->maxLineWidth && $currentLine === []
+                    // Append if removed whitespace would overflow -> reset whitespace counting to prevent overflow
+                    || $this->trim && ($whitespacesWidth + $symbolWidth) > $this->maxLineWidth && $currentLine === []
+                    // Append if complete word would overflow
+                    || !$this->trim && ($currentWordWidth + $whitespacesWidth + $symbolWidth) > $this->maxLineWidth && $currentLine === []
+                ) {
+                    if ($currentLine !== [] || !$this->trim) {
+                        // Also append whitespaces if not trimming or current line is not empty
+                        $currentLine = [...$currentLine, ...$whitespaceBuffer];
+                        $currentLineWidth += $whitespacesWidth;
+                    }
+
+                    // Append trimmed word
+                    $currentLine = [...$currentLine, ...$currentWord];
+                    $currentLineWidth += $currentWordWidth;
+                    $currentWord = [];
+
+                    // Clear whitespace buffer
+                    $whitespaceBuffer = [];
+                    $whitespacesWidth = 0;
+                    $currentWordWidth = 0;
+                }
+
+                if (
+                    // Append the unfinished wrapped line to wrapped lines if it is as wide as max line width
+                    $currentLineWidth >= $this->maxLineWidth
+                    // or if it would be too long with the current partially processed word added
+                    || ($currentLineWidth + $whitespacesWidth + $currentWordWidth) >= $this->maxLineWidth && $symbolWidth > 0
+                ) {
+                    $remainingWidth = max($this->maxLineWidth - $currentLineWidth, 0);
+
+                    $wrappedLines[] = $this->processLine($currentLine, $lineAlignment);
+                    $currentLine = [];
+                    $currentLineWidth = 0;
+
+                    // Remove all whitespaces till end of just appended wrapped line + next whitespace
+                    $this->removeWhitespaces($whitespaceBuffer, $whitespacesWidth, $remainingWidth);
+
+                    // In case all whitespaces have been exhausted, prevent first whitespace to count towards next word
+                    if ($isWhitespace) {
+                        continue;
+                    }
+                }
+
+                // Append symbol to unfinished, partially processed word
+                if ($isWhitespace) {
+                    $whitespaceBuffer[] = $symbol;
+                    $whitespacesWidth += $symbolWidth;
+                } else {
+                    $currentWord[] = $symbol;
+                    $currentWordWidth += $symbolWidth;
+                }
+
+                $hasSeenNonWhitespace = !$isWhitespace;
+            }
+
+            // Append remaining text parts
+            if ($currentWord !== [] || $whitespaceBuffer !== []) {
+                if ($currentLine === [] && $currentWord === []) {
+                    $wrappedLines[] = $this->processLine([], $lineAlignment);
+                } elseif(!$this->trim || $currentLine !== []) {
+                    $currentLine = [...$currentLine, ...$whitespaceBuffer];
+                    $whitespaceBuffer = [];
+                }
+                $currentLine = [...$currentLine, ...$currentWord];
+            }
+
+            // Append remaining line
+            if ($currentLine !== []) {
+                $wrappedLines[] = $this->processLine($currentLine, $lineAlignment);
+            }
+
+            // Append empty line if there was nothing to wrap in the first place
+            if ($wrappedLines === []) {
+                $wrappedLines[] = $this->processLine([], $lineAlignment);
+            }
+        }
+
+        yield from $wrappedLines;
+    }
+
+    /**
+     * @param StyledGrapheme[] $currentLine
+     * @return array{list<StyledGrapheme>,int,HorizontalAlignment}
+     */
+    private function processLine(array $currentLine, HorizontalAlignment $alignment): array
+    {
+        $lineWidth = array_reduce($currentLine, function (int $width, StyledGrapheme $grapheme): int {
+            return $width + $grapheme->symbolWidth();
+        }, 0);
+
+        return [$currentLine, $lineWidth, $alignment];
+    }
+
+    /**
+     * @param StyledGrapheme[] $whitespaceBuffer
+     */
+    private function removeWhitespaces(array &$whitespaceBuffer, int &$whitespacesWidth, int &$remainingWidth): void
+    {
+        $firstWhitespace = array_shift($whitespaceBuffer);
+        while ($firstWhitespace instanceof StyledGrapheme) {
+            $symbolWidth = $firstWhitespace->symbolWidth();
+            $whitespacesWidth -= $symbolWidth;
+            if ($symbolWidth > $remainingWidth) {
+                break;
+            }
+            $remainingWidth -= $symbolWidth;
+            $firstWhitespace = array_shift($whitespaceBuffer);
+        }
+    }
+
+    private function isWhitespace(StyledGrapheme $symbol): bool
+    {
+        return preg_match('/\p{Z}/u', $symbol->symbol) && $symbol->symbol !== self::NBSP;
+    }
+}

--- a/tests/Example/snapshot/Blocks.snapshot
+++ b/tests/Example/snapshot/Blocks.snapshot
@@ -2,19 +2,19 @@
 │ [q]uit │ events │ canvas │ chart │ list │ table │ blocks │ sprite │ colors │ │
 └──────────────────────────────────────────────────────────────────────────────┘
 ┌Borders::ALL──────────────────────────┐Borders::NONE                           
-│Lorem ipsum dolor sit amet, consectetu│Lorem ipsum dolor sit amet, consectetur 
-│r adipiscing elit, sed do eiusmod temp│adipiscing elit, sed do eiusmod tempor i
-└──────────────────────────────────────┘ncididunt ut labore et dolore magna aliq
+│Lorem ipsum dolor sit amet,           │Lorem ipsum dolor sit amet, consectetur 
+│consectetur adipiscing elit, sed do   │adipiscing elit, sed do eiusmod tempor  
+└──────────────────────────────────────┘incididunt ut labore et dolore magna    
 │Borders::LEFT                          Borders::RIGHT                         │
 │Lorem ipsum dolor sit amet, consecteturLorem ipsum dolor sit amet, consectetur│
-│ adipiscing elit, sed do eiusmod tempor adipiscing elit, sed do eiusmod tempor│
-│ incididunt ut labore et dolore magna a incididunt ut labore et dolore magna a│
+│adipiscing elit, sed do eiusmod tempor adipiscing elit, sed do eiusmod tempor │
+│incididunt ut labore et dolore magna   incididunt ut labore et dolore magna   │
 Borders::TOP────────────────────────────Borders::BOTTOM                         
 Lorem ipsum dolor sit amet, consectetur Lorem ipsum dolor sit amet, consectetur 
-adipiscing elit, sed do eiusmod tempor iadipiscing elit, sed do eiusmod tempor i
-ncididunt ut labore et dolore magna aliq────────────────────────────────────────
+adipiscing elit, sed do eiusmod tempor  adipiscing elit, sed do eiusmod tempor  
+incididunt ut labore et dolore magna    ────────────────────────────────────────
 ┌BordersType::Plain────────────────────┐╭BordersType::Rounded──────────────────╮
-│Lorem ipsum dolor sit amet, consectetu││Lorem ipsum dolor sit amet, consectetu│
-│r adipiscing elit, sed do eiusmod temp││r adipiscing elit, sed do eiusmod temp│
+│Lorem ipsum dolor sit amet,           ││Lorem ipsum dolor sit amet,           │
+│consectetur adipiscing elit, sed do   ││consectetur adipiscing elit, sed do   │
 └──────────────────────────────────────┘╰──────────────────────────────────────╯
 ╚BordersType::Double═══════════════════╗┗BordersType::Thick━━━━━━━━━━━━━━━━━━━━┓

--- a/tests/Unit/Extension/Core/Widget/ParagraphRendererTest.php
+++ b/tests/Unit/Extension/Core/Widget/ParagraphRendererTest.php
@@ -7,6 +7,7 @@ namespace PhpTui\Tui\Tests\Unit\Extension\Core\Widget;
 use Generator;
 use PhpTui\Tui\Display\Area;
 use PhpTui\Tui\Display\Buffer;
+use PhpTui\Tui\Extension\Core\Widget\Paragraph\Wrap;
 use PhpTui\Tui\Extension\Core\Widget\ParagraphWidget;
 use PhpTui\Tui\Text\Line;
 use PhpTui\Tui\Text\Text;
@@ -56,12 +57,16 @@ final class ParagraphRendererTest extends WidgetTestCase
     {
         yield 'simple' => [
             Area::fromDimensions(8, 1),
-            ParagraphWidget::fromText(Text::fromString('Gday')),
+            ParagraphWidget::fromText(
+                Text::fromString('Gday')
+            )->wrap(Wrap::Character),
             'Gday    ',
         ];
         yield 'wrap' => [
             Area::fromDimensions(8, 3),
-            ParagraphWidget::fromText(Text::fromString('Gday mate lets put another shrimp on the barby')),
+            ParagraphWidget::fromText(
+                Text::fromString('Gday mate lets put another shrimp on the barby')
+            )->wrap(Wrap::Character),
             implode("\n", [
                 'Gday mat',
                 'e lets p',
@@ -74,7 +79,7 @@ final class ParagraphRendererTest extends WidgetTestCase
                 Text::fromLine(
                     Line::fromString('Gday')->alignment(HorizontalAlignment::Right)
                 )
-            ),
+            )->wrap(Wrap::Character),
             '    Gday',
         ];
         yield 'align left and right' => [
@@ -82,16 +87,311 @@ final class ParagraphRendererTest extends WidgetTestCase
             ParagraphWidget::fromLines(
                 Line::fromString('1/1')->alignment(HorizontalAlignment::Left),
                 Line::fromString('About')->alignment(HorizontalAlignment::Right),
-            ),
+            )->wrap(Wrap::Word),
             '1/1       ',
             '     About',
         ];
-        yield 'unicode' => [
+        yield 'line with unicode wrapped by character' => [
             Area::fromDimensions(14, 1),
             ParagraphWidget::fromText(
                 Text::fromString('こんにちは, 世界! 😃')
-            ),
+            )->wrap(Wrap::Character),
             'こんにちは, 世',
+        ];
+        yield 'line with lorem ipsum wrapped by character' => [
+            Area::fromDimensions(18, 3),
+            ParagraphWidget::fromText(
+                Text::fromString('Lorem ipsum dolor sit amet, consectetur')
+            )->wrap(Wrap::Character),
+            implode("\n", [
+                'Lorem ipsum dolor ',
+                'sit amet, consecte',
+                'tur               ',
+            ]),
+        ];
+        yield 'line with lorem ipsum wrapped by word' => [
+            Area::fromDimensions(18, 3),
+            ParagraphWidget::fromText(
+                Text::fromString('Lorem ipsum dolor sit amet, consectetur')
+            )->wrap(Wrap::Word),
+            implode("\n", [
+                'Lorem ipsum dolor ',
+                'sit amet,         ',
+                'consectetur       ',
+            ]),
+        ];
+        yield 'line with hello wrapped by word' => [
+            Area::fromDimensions(10, 2),
+            ParagraphWidget::fromText(
+                Text::fromString('Hello Goodbye')
+            )->wrap(Wrap::Word),
+            implode("\n", [
+                'Hello     ',
+                'Goodbye   ',
+            ]),
+        ];
+        yield 'line with hello wrapped by character' => [
+            Area::fromDimensions(10, 2),
+            ParagraphWidget::fromText(
+                Text::fromString('Hello Goodbye')
+            )->wrap(Wrap::Character),
+            implode("\n", [
+                'Hello Good',
+                'bye       ',
+            ]),
+        ];
+        yield 'line with welcome to the PHP-TUI 1' => [
+            Area::fromDimensions(15, 3),
+            ParagraphWidget::fromText(
+                Text::fromString('Welcome to the PHP-TUI 🐘 application.'),
+            )->wrap(Wrap::Word),
+            implode("\n", [
+                'Welcome to the ',
+                'PHP-TUI 🐘     ',
+                'application.   ',
+            ]),
+        ];
+        yield 'line with welcome to the PHP-TUI 2' => [
+            Area::fromDimensions(8, 4),
+            ParagraphWidget::fromText(
+                Text::fromString('Welcome to the PHP-TUI 🐘'),
+            )->wrap(Wrap::Word),
+            implode("\n", [
+                'Welcome ',
+                'to the  ',
+                'PHP-TUI ',
+                '🐘      ',
+            ]),
+        ];
+        yield 'line with multiple a letters preserving spaces' => [
+            Area::fromDimensions(20, 2),
+            ParagraphWidget::fromText(
+                Text::fromString('AAAAAAAAAAAAAAAAAAAA    AAA'),
+            )->wrap(Wrap::Word),
+            implode("\n", [
+                'AAAAAAAAAAAAAAAAAAAA',
+                '   AAA              ',
+            ]),
+        ];
+        yield 'line with multiple a letters while not preserving spaces' => [
+            Area::fromDimensions(20, 2),
+            ParagraphWidget::fromText(
+                Text::fromString('AAAAAAAAAAAAAAAAAAAA    AAA'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'AAAAAAAAAAAAAAAAAAAA',
+                'AAA                 ',
+            ]),
+        ];
+        yield 'line with multiple words wrapped by character' => [
+            Area::fromDimensions(20, 5),
+            ParagraphWidget::fromText(
+                Text::fromString('abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab c d e f g h i j k l m n o'),
+            )->wrap(Wrap::Character),
+            implode("\n", [
+                'abcd efghij klmnopab',
+                'cd efgh ijklmnopabcd',
+                'efg hijkl mnopab c d',
+                ' e f g h i j k l m n',
+                ' o                  ',
+            ]),
+        ];
+        yield 'line with multiple words and single spaces' => [
+            Area::fromDimensions(20, 5),
+            ParagraphWidget::fromText(
+                Text::fromString('abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab c d e f g h i j k l m n o'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'abcd efghij         ',
+                'klmnopabcd efgh     ',
+                'ijklmnopabcdefg     ',
+                'hijkl mnopab c d e f',
+                'g h i j k l m n o   ',
+            ]),
+        ];
+        yield 'line with multiple words and multiple spaces' => [
+            Area::fromDimensions(20, 5),
+            ParagraphWidget::fromText(
+                Text::fromString('abcd efghij    klmnopabcd efgh     ijklmnopabcdefg hijkl mnopab c d e f g h i j k l m n o'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'abcd efghij         ',
+                'klmnopabcd efgh     ',
+                'ijklmnopabcdefg     ',
+                'hijkl mnopab c d e f',
+                'g h i j k l m n o   ',
+            ]),
+        ];
+        yield 'line with short words' => [
+            Area::fromDimensions(4, 3),
+            ParagraphWidget::fromText(
+                Text::fromString('abcd efghij'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'abcd',
+                'efgh',
+                'ij  ',
+            ]),
+        ];
+        yield 'line with with single space' => [
+            Area::fromDimensions(5, 2),
+            ParagraphWidget::fromText(
+                Text::fromString('hello world'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'hello',
+                'world',
+            ]),
+        ];
+        yield 'line with with multiple spaces by word' => [
+            Area::fromDimensions(5, 7),
+            ParagraphWidget::fromText(
+                Text::fromString('hello                           world '),
+            )->wrap(Wrap::Word),
+            implode("\n", [
+                'hello',
+                '     ',
+                '     ',
+                '     ',
+                '     ',
+                '  wor',
+                'ld   ',
+            ]),
+        ];
+        yield 'line with with multiple spaces by word trimmed' => [
+            Area::fromDimensions(5, 3),
+            ParagraphWidget::fromText(
+                Text::fromString('hello                           world '),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'hello',
+                '     ',
+                'world',
+            ]),
+        ];
+        yield 'line with max line width 1' => [
+            Area::fromDimensions(1, 1),
+            ParagraphWidget::fromText(
+                Text::fromString('abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab '),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'a',
+            ]),
+        ];
+        yield 'line with max line width 1 with double width characters' => [
+            Area::fromDimensions(1, 5),
+            ParagraphWidget::fromText(
+                Text::fromString("コンピュータ上で文字を扱う場合、典型的には文字\naaa\naによる通信を行う場合にその両端点では、"),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                ' ',
+                'a',
+                'a',
+                'a',
+                'a',
+            ]),
+        ];
+        yield 'line with single char with multiples spaces' => [
+            Area::fromDimensions(20, 2),
+            ParagraphWidget::fromText(
+                Text::fromString('a                                                                     '),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'a                   ',
+                '                    ',
+            ]),
+        ];
+        yield 'line with short lines' => [
+            Area::fromDimensions(20, 7),
+            ParagraphWidget::fromText(
+                Text::fromString("abcdefg\nhijklmno\npabcdefg\nhijklmn\nopabcdefghijk\nlmnopabcd\n\n\nefghijklmno"),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'abcdefg             ',
+                'hijklmno            ',
+                'pabcdefg            ',
+                'hijklmn             ',
+                'opabcdefghijk       ',
+                'lmnopabcd           ',
+                'efghijklmno         ',
+            ]),
+        ];
+        yield 'line with long word' => [
+            Area::fromDimensions(20, 4),
+            ParagraphWidget::fromText(
+                Text::fromString('abcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmno'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'abcdefghijklmnopabcd',
+                'efghijklmnopabcdefgh',
+                'ijklmnopabcdefghijkl',
+                'mno                 ',
+            ]),
+        ];
+        yield 'line with mixed length words' => [
+            Area::fromDimensions(20, 5),
+            ParagraphWidget::fromText(
+                Text::fromString('abcd efghij klmnopabcdefghijklmnopabcdefghijkl mnopab cdefghi j klmno'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'abcd efghij         ',
+                'klmnopabcdefghijklmn',
+                'opabcdefghijkl      ',
+                'mnopab cdefghi j    ',
+                'klmno               ',
+            ]),
+        ];
+        yield 'line with double width chars' => [
+            Area::fromDimensions(20, 5),
+            ParagraphWidget::fromText(
+                Text::fromString('コンピュータ上で文字を扱う場合、典型的には文字による通信を行う場合にその両端点では、'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'コンピュータ上で文字',
+                'を扱う場合、典型的に',
+                'は文字による通信を行',
+                'う場合にその両端点で',
+                'は、                ',
+            ]),
+        ];
+        yield 'line with double width chars with spaces' => [
+            Area::fromDimensions(20, 6),
+            ParagraphWidget::fromText(
+                Text::fromString('コンピュ ータ上で文字を扱う場合、 典型的には文 字による 通信を行 う場合にその両端点では、'),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                'コンピュ            ',
+                'ータ上で文字を扱う場',
+                '合、 典型的には文   ',
+                '字による 通信を行   ',
+                'う場合にその両端点で',
+                'は、                ',
+            ]),
+        ];
+        yield 'line with indentation preserved' => [
+            Area::fromDimensions(10, 6),
+            ParagraphWidget::fromText(
+                Text::fromString("               4 Indent\n                 must wrap!"),
+            )->wrap(Wrap::Word),
+            implode("\n", [
+                '          ',
+                '    4     ',
+                'Indent    ',
+                '          ',
+                '      must',
+                'wrap!     ',
+            ]),
+        ];
+        yield 'line with indentation not preserved' => [
+            Area::fromDimensions(10, 3),
+            ParagraphWidget::fromText(
+                Text::fromString("               4 Indent\n                 must wrap!"),
+            )->wrap(Wrap::WordTrimmed),
+            implode("\n", [
+                '4 Indent  ',
+                '          ',
+                'must wrap!',
+            ]),
         ];
     }
 }


### PR DESCRIPTION
Closes https://github.com/php-tui/php-tui/issues/202 and https://github.com/php-tui/php-tui/issues/203

This implementation is heavily based on Ratatui's. You can review tests (the last two ones are the best ones) to understand the differences between breaking by `Word` vs `WordTrimmed` (there is a significant difference).

The `None` variant is simply an alias for `Character`. Notice that `None` is the default wrapping logic used if none is specified.