### PR TITLE
Chore: clean up `VectorUtil` Implementation

### DIFF
--- a/src/Math/VectorUtil.php
+++ b/src/Math/VectorUtil.php
@@ -19,14 +19,7 @@ final class VectorUtil
      */
     public static function max(array $vector): int|float|null
     {
-        if ([] === $vector) {
-            return null;
-        }
-        if (count($vector) === 1) {
-            return $vector[array_key_first($vector)];
-        }
-
-        return max(...$vector);
+        return $vector === [] ? null : max($vector);
     }
 
     /**
@@ -42,13 +35,6 @@ final class VectorUtil
      */
     public static function min(array $vector): int|float|null
     {
-        if ([] === $vector) {
-            return null;
-        }
-        if (count($vector) === 1) {
-            return $vector[array_key_first($vector)];
-        }
-
-        return min(...$vector);
+        return $vector === [] ? null : min($vector);
     }
 }

--- a/tests/Unit/Model/Math/VectorUtilTest.php
+++ b/tests/Unit/Model/Math/VectorUtilTest.php
@@ -22,6 +22,16 @@ final class VectorUtilTest extends TestCase
     }
 
     /**
+     * @param list<number> $vector
+     * @param int|float|null $expected
+     */
+    #[DataProvider('provideMin')]
+    public function testMin(array $vector, mixed $expected): void
+    {
+        self::assertEquals($expected, VectorUtil::min($vector));
+    }
+
+    /**
      * @return Generator<array{list<number>,number|null}>
      */
     public static function provideMax(): Generator
@@ -45,6 +55,33 @@ final class VectorUtilTest extends TestCase
         yield [
             [6,1,3],
             6
+        ];
+    }
+
+    /**
+     * @return Generator<array{list<number>,number|null}>
+     */
+    public static function provideMin(): Generator
+    {
+        yield [
+            [],
+            null
+        ];
+        yield [
+            [1],
+            1,
+        ];
+        yield [
+            [1.2],
+            1.2,
+        ];
+        yield [
+            [1.2,3.4],
+            1.2,
+        ];
+        yield [
+            [6,1,3],
+            1
         ];
     }
 }


### PR DESCRIPTION
I believe `max()` and `min()` receiving the entire array can handle all situations here. Or am I missing something?